### PR TITLE
Watch dummy application files when running make test-watch

### DIFF
--- a/template/{{app_name}}/engines/flex/Guardfile
+++ b/template/{{app_name}}/engines/flex/Guardfile
@@ -37,7 +37,7 @@ guard :rspec, cmd: "bundle exec rspec" do
   watch(rspec.spec_files)
 
   # Dummy application
-  # Ignore writes to spec/dummy/log/test.log since that gets written during test runs
+  # Ignore spec/dummy/log/test.log since that gets written during test runs
   watch(%r{^#{rspec.spec_dir}/dummy/(?!log/test\.log)}) { rspec.spec_dir }
 
   # Ruby files


### PR DESCRIPTION
## Changes

see title

## Context

added some logging to figure out what was causing the infinite loop

## Testing

tested make test-watch, saving changes to dummy app now retriggers tests without infinite looping