### PR TITLE
Update CD to run bundle update flex

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,8 +48,10 @@ jobs:
           ruby-version: ${{ steps.ruby-version.outputs.RUBY_VERSION }}
 
       - name: Update flex
-        working-directory: project-repo
-        run: cd ${{ matrix.project.app }} && bundle update flex
+        working-directory: project-repo/${{ matrix.project.app }}
+        run: |
+          bundle install
+          bundle update flex
 
       - name: Commit changes
         working-directory: project-repo


### PR DESCRIPTION
## Changes

see title

## Context

Updating CD to update pfml-starter-kit-app demo app's version of flex using bundle update instead of platform-cli

## Testing

tested by running manually from this branch
 https://github.com/navapbc/flex-sdk/actions/runs/14939118968/job/41973076822