### PR TITLE
Make validate_<memorable_date_attribute> method more clear

### DIFF
--- a/app/lib/flex/attributes.rb
+++ b/app/lib/flex/attributes.rb
@@ -49,7 +49,12 @@ module Flex
             value = send(name)
             raw_value = read_attribute_before_type_cast(name)
 
-            if raw_value.present? && value.nil?
+            # If model.<attribute> is nil, but model.<attribute>_before_type_cast is not nil,
+            # that means the application failed to cast the value to the appropriate type in
+            # order to complete the attribute assignment. This means the original value
+            # is invalid.
+            did_type_cast_fail = value.nil? && raw_value.present?
+            if did_type_cast_fail
               errors.add(name, :invalid_memorable_date)
             end
           end


### PR DESCRIPTION
## Changes



## Context

> In situations like this where logic might not be as clear, could we take a step to make it more clear for devs in the future? Could either store the expression into a variable with a name that makes it clear what's happening or wrap it in a function with a name that makes it clear. Something like: can_cast_to_date = raw_value.present? && value.nil?. Then future devs will at least know what this expression overall does. 

See https://github.com/navapbc/flex-sdk/pull/60#discussion_r2085160038

## Testing

CI