### PR TITLE
Fix error messages

### DIFF
--- a/app/helpers/flex/form_builder.rb
+++ b/app/helpers/flex/form_builder.rb
@@ -219,7 +219,7 @@ module Flex
     def field_error(attribute)
       return unless has_error?(attribute)
 
-      @template.content_tag(:span, object.errors[attribute].to_sentence, class: "usa-error-message")
+      @template.content_tag(:span, object.errors.full_messages_for(attribute).first, class: "usa-error-message")
     end
 
     def fieldset(legend, options = {}, &block)

--- a/config/locales/flex/en.yml
+++ b/config/locales/flex/en.yml
@@ -16,9 +16,10 @@ en:
       boolean_true: "Yes"
       boolean_false: "No"
       date_picker_format: "Format: mm/dd/yyyy"
+      memorable_date_hint: "For example: January 19 2000"
       optional: "Optional"
       select_month: "- Select -"
       tax_id_format: "For example, 123456789"
   errors:
     messages:
-      invalid_date: "Invalid date"
+      invalid_date: "is an invalid date"

--- a/config/locales/flex/es-US.yml
+++ b/config/locales/flex/es-US.yml
@@ -16,6 +16,7 @@ es-US:
       boolean_true: "Sí"
       boolean_false: "No"
       date_picker_format: "Formato: mm/dd/aaaa"
+      memorable_date_hint: "Por ejemplo: Enero 19 2000"
       optional: "Opcional"
       select_month: "- Seleccionar -"
       tax_id_format: "Por ejemplo, 123456789"

--- a/spec/dummy/spec/lib/flex/attributes_spec.rb
+++ b/spec/dummy/spec/lib/flex/attributes_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Flex::Attributes do
         expect(object.date_of_birth).to be_nil
         expect(object.date_of_birth_before_type_cast).to eq(input_hash)
         expect(object).not_to be_valid
-        expect(object.errors["date_of_birth"]).to include("Invalid date")
+        expect(object.errors.full_messages_for("date_of_birth")).to eq([ "Date of birth is an invalid date" ])
       end
     end
   end

--- a/spec/helpers/flex/form_builder_spec.rb
+++ b/spec/helpers/flex/form_builder_spec.rb
@@ -333,7 +333,7 @@ RSpec.describe Flex::FormBuilder do
       end
 
       it 'displays the error message' do
-        expect(result).to have_element(:span, text: 'Invalid date')
+        expect(result).to have_element(:span, text: 'Date of birth is an invalid date')
       end
     end
   end


### PR DESCRIPTION
## Changes

> What was added, updated, or removed in this PR.

## Context

- Error messages were displaying as sentence fragments. I didn't look too deeply but my guess is `to_sentence` is part of an older Rails version. In Rails 8 looks like it should be errors.full_messages_for(attribute)
- Note: This only displays the first error message for a field if there are multiple errors on that same field. I don't know design-wise whether we'd ever want to show more than one error message for a single field, seems like an odd use case. Maybe we can put a pin on that.

## Testing

Tested with updated tests, and will do more testing in demo app