### PR TITLE
Add user_id to ApplicationForm

### DIFF
--- a/app/models/flex/application_form.rb
+++ b/app/models/flex/application_form.rb
@@ -25,6 +25,8 @@ module Flex
     protected attr_writer :status, :integer
     enum :status, in_progress: 0, submitted: 1
 
+    attribute :user_id, :string
+
     after_create :publish_created
     before_update :prevent_changes_if_submitted, if: :was_submitted?
 


### PR DESCRIPTION
Resolves https://linear.app/nava-platform/issue/TSS-50/add-user-id-to-applicationform

## Context

ApplicationForm should have a user_id. We can assume all apps will have a users table
I think this should be nullable since I can imagine a situation where a user creates an application via the contact center without having an online portal account.

This PR doesn't add user_id to the dummy app since the dummy app doesn't have any users yet, but maybe that's something we can add in a future PR. https://linear.app/nava-platform/issue/TSS-51/add-user-model-to-dummy-app

## Testing

CI