### PR TITLE
Add view path for task details partials

### DIFF
--- a/app/controllers/flex/tasks_controller.rb
+++ b/app/controllers/flex/tasks_controller.rb
@@ -5,6 +5,7 @@ module Flex
     helper DateHelper
 
     before_action :set_task, only: %i[ show update ]
+    before_action :add_task_details_view_path, only: %i[ show ]
 
     def task_class
       controller_path.classify.constantize
@@ -31,6 +32,10 @@ module Flex
 
     def set_task
       @task = task_class.find(params[:id]) if params[:id].present?
+    end
+
+    def add_task_details_view_path
+      prepend_view_path "app/views/#{controller_path}"
     end
 
     def index_filter_params

--- a/app/views/flex/tasks/show.html.erb
+++ b/app/views/flex/tasks/show.html.erb
@@ -57,7 +57,7 @@
       <% if content_for?(:task_details_partial) %>
         <%= yield(:task_details_partial) %>
       <% else %>
-        <%= render partial: "tasks/details/#{task.type.underscore}", locals: local_assigns.to_h %>
+        <%= render partial: "details/#{task.type.underscore}", locals: local_assigns.to_h %>
       <% end %>
     </section>
   </main>


### PR DESCRIPTION
## Changes

- Updated TasksController to prepend an additional partials route, only for the `show` method
    - This allows the parent app to name their tasks directory whatever they want instead of enforcing that the tasks app must use `tasks` as the directory name

## Context

When trying to render task details partials in the `demo` app, I ran into a problem with the strictly defined partial route in Flex. Flex had defined `task/details/{partial name}` as the route to find the partial...which meant that the parent app would always need to have their tasks route be in a `task` directory. Adding this view directory for only the `show` route allows the parent app to name their tasks directory whatever they want.

## Testing

- CI
- Additionally, if you run the dummy app locally, you should be able to load the tasks index and show pages
