### PR TITLE
Make show url from index simpler

### DIFF
--- a/app/views/flex/tasks/index.html.erb
+++ b/app/views/flex/tasks/index.html.erb
@@ -62,7 +62,7 @@
             <%= local_en_us task.due_on %>
           </td>
           <td data-sort-value="<%= task.type %>">
-            <%= link_to t("tasks.types.#{task.type.underscore}"), task_path(task) %>
+            <%= link_to t("tasks.types.#{task.type.underscore}"), url_for(only_path: true, action: :show, id: task.id.to_s) %>
           </td>
           <td data-sort-value="<%= task.case_id %>"><%= task.case_id %></td>
           <td data-sort-value="<%= time_since_epoch task.created_at %>">


### PR DESCRIPTION
## Changes

- Updated the hyperlink url to be more dynamic, utilizing the current path

## Context

Previously I was using `task_path`, but that forced the parent application to name their route `tasks` or do other configuration. This allows the parent application to be more flexible with their route usage.

## Testing

- CI
- Run the dummy app and ensure that the index and show routes for tasks loads correctly
