### PR TITLE
Change app submitted output to be debug log

### DIFF
--- a/app/models/flex/application_form.rb
+++ b/app/models/flex/application_form.rb
@@ -38,7 +38,7 @@ module Flex
     #
     # @return [Boolean] True if the submission was successful
     def submit_application
-      puts "Submitting application with ID: #{id}"
+      Rails.logger.debug "Submitting application with ID: #{id}"
       self[:status] = :submitted
       self[:submitted_at] = Time.current
       save!


### PR DESCRIPTION
## Changes

Updated the log that occurs on application submission to use `Rails.logger.debug` instead of `puts`.

## Context

Previously we were using `puts` to output a log that an application has been submitted.

## Testing

- CI / Tests pass
- When running tests, no messages are output to the console about an application being submitted
