### PR TITLE
Fix test watch command running infinitely

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -78,5 +78,4 @@ guard :rspec, cmd: "bundle exec rspec" do
   ignore %r{^#{rspec.spec_dir}/dummy/tmp/}
   ignore %r{^#{rspec.spec_dir}/dummy/log/}
   ignore %r{^#{rspec.spec_dir}/dummy/storage/}
-  # puts dsl.pretty_inspect
 end


### PR DESCRIPTION
## Changes

- Ignored more directories from the Guardfile

## Context

- Running `make test-watch` was infinitely running tests. This addresses that.

## Testing

- Running `make test-watch` and checking to ensure that the tests don't re-run infinitely
