### PR TITLE
Remove task_class from tasks_controller.rb

### DIFF
--- a/app/controllers/flex/tasks_controller.rb
+++ b/app/controllers/flex/tasks_controller.rb
@@ -7,10 +7,6 @@ module Flex
     before_action :set_task, only: %i[ show update ]
     before_action :add_task_details_view_path, only: %i[ show ]
 
-    def task_class
-      controller_path.classify.constantize
-    end
-
     def index
       @task_types = Flex::Task.distinct(:type).unscope(:order).pluck(:type)
       @tasks = filter_tasks
@@ -31,7 +27,7 @@ module Flex
     private
 
     def set_task
-      @task = task_class.find(params[:id]) if params[:id].present?
+      @task = Flex::Task.find(params[:id]) if params[:id].present?
     end
 
     def add_task_details_view_path
@@ -43,7 +39,7 @@ module Flex
     end
 
     def filter_tasks
-      tasks = filter_tasks_by_date(task_class.all, index_filter_params[:filter_date])
+      tasks = filter_tasks_by_date(Flex::Task.all, index_filter_params[:filter_date])
       tasks = filter_tasks_by_type(tasks, index_filter_params[:filter_type])
       tasks = filter_tasks_by_status(tasks, index_filter_params[:filter_status])
 


### PR DESCRIPTION
Resolves TSS-93

## Changes

- Removed `task_class` from the `Flex::TasksController` in favor of only using `Flex::Task` instead

## Context

- If I try to use the specific `task_class` related to the controller, unfortunately it does not return multiple task types and will instead only return tasks from the one specific `task_class`. To get it to return multiple task types at the same time, I have to use `Flex::Task`.
- This is related to [this PR comment](https://github.com/navapbc/pfml-starter-kit-app/pull/318/files#r2114661296)

## Testing

- CI
- Run the app locally and navigate to `/tasks`
    - Ensure that the `/tasks` route loads as expected
