### PR TITLE
Refactor attributes.rb to be smaller

### DIFF
--- a/app/lib/flex/attributes.rb
+++ b/app/lib/flex/attributes.rb
@@ -62,24 +62,9 @@ module Flex
           return
         end
 
-        case type
-        when :address
-          address_attribute name, options
-        when :memorable_date
-          memorable_date_attribute name, options
-        when :money
-          money_attribute name, options
-        when :name
-          name_attribute name, options
-        when :tax_id
-          tax_id_attribute name, options
-        when :us_date
-          us_date_attribute name, options
-        when :year_quarter
-          year_quarter_attribute name, options
-        else
-          raise ArgumentError, "Unsupported attribute type: #{type}"
-        end
+        raise ArgumentError, "Unsupported attribute type: #{type}" unless respond_to?("#{type}_attribute")
+
+        send("#{type}_attribute", name, options)
       end
     end
   end


### PR DESCRIPTION
Resolves https://linear.app/nava-platform/issue/TSS-158/refactor-flex-attributes-method-to-be-smaller

## Changes

Replaces the case statement in attributes.rb with a more dynamic conventions based approach to just calling the "#{type}_attribute" class method. This enforces the convention that attribute methods need to be named as such.

## Context

See issue

## Testing

CI still passes