### PR TITLE
DRY up value object attribute specs using shared examples

### DIFF
--- a/spec/factories/flex/addresses_factory.rb
+++ b/spec/factories/flex/addresses_factory.rb
@@ -8,6 +8,13 @@ FactoryBot.define do
       zip_code { Faker::Address.zip_code }
     end
 
+    trait :invalid do
+      street_line_1 { Faker::Address.street_address }
+      city { nil } # Missing city
+      state { Faker::Address.state_abbr }
+      zip_code { Faker::Address.zip_code }
+    end
+
     trait :with_street_line_2 do
       street_line_2 { Faker::Address.secondary_address }
     end

--- a/spec/factories/flex/year_quarter_factory.rb
+++ b/spec/factories/flex/year_quarter_factory.rb
@@ -2,5 +2,10 @@ FactoryBot.define do
   factory :year_quarter, class: 'Flex::YearQuarter' do
     year { Faker::Number.between(from: 1950, to: 2050) }
     quarter { Faker::Number.between(from: 1, to: 4) }
+
+    trait :invalid do
+      year { Faker::Number.between(from: 1950, to: 2050) }
+      quarter { 5 }
+    end
   end
 end

--- a/spec/lib/flex/attributes/address_attribute_spec.rb
+++ b/spec/lib/flex/attributes/address_attribute_spec.rb
@@ -1,120 +1,21 @@
 require "rails_helper"
+require_relative "value_object_attribute_shared_examples"
 
 # rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe Flex::Attributes::AddressAttribute do
-  let(:object) { TestRecord.new }
-  let(:street_line_1) { "456 Oak Ave" } # rubocop:disable RSpec/IndexedLet
-  let(:street_line_2) { "Unit 7C" } # rubocop:disable RSpec/IndexedLet
-  let(:city) { "San Francisco" }
-  let(:state) { "CA" }
-  let(:zip_code) { "94107" }
-
-  it "allows setting address as a value object" do
-    address = Flex::Address.new(street_line_1:, street_line_2:, city:, state:, zip_code:)
-    object.address = address
-
-    expect(object.address).to eq(Flex::Address.new(street_line_1:, street_line_2:, city:, state:, zip_code:))
-    expect(object.address_street_line_1).to eq(street_line_1)
-    expect(object.address_street_line_2).to eq(street_line_2)
-    expect(object.address_city).to eq(city)
-    expect(object.address_state).to eq(state)
-    expect(object.address_zip_code).to eq(zip_code)
-  end
-
-  it "allows setting address as a hash" do
-    object.address = {
-      street_line_1:,
-      street_line_2:,
-      city:,
-      state:,
-      zip_code:
-    }
-
-    expect(object.address).to eq(Flex::Address.new(street_line_1:, street_line_2:, city:, state:, zip_code:))
-    expect(object.address_street_line_1).to eq(street_line_1)
-    expect(object.address_street_line_2).to eq(street_line_2)
-    expect(object.address_city).to eq(city)
-    expect(object.address_state).to eq(state)
-    expect(object.address_zip_code).to eq(zip_code)
-  end
-
-  it "allows setting nested address attributes directly" do
-    object.address_street_line_1 = street_line_1
-    object.address_street_line_2 = street_line_2
-    object.address_city = city
-    object.address_state = state
-    object.address_zip_code = zip_code
-    expect(object.address).to eq(Flex::Address.new(street_line_1:, street_line_2:, city:, state:, zip_code:))
-  end
-
-  it "preserves values exactly as entered without normalization" do
-    object.address = {
+  include_examples "value object shared examples", Flex::Address, :address,
+    valid_nested_attributes: FactoryBot.attributes_for(:address, :base, :with_street_line_2),
+    nested_attributes_without_normalization: {
       street_line_1: "789 BROADWAY",
       street_line_2: "",
       city: "new york",
       state: "NY",
       zip_code: "10003"
-    }
-
-    expect(object.address).to eq(Flex::Address.new(street_line_1: "789 BROADWAY", street_line_2: "", city: "new york", state: "NY", zip_code: "10003"))
-    expect(object.address_street_line_1).to eq("789 BROADWAY")
-    expect(object.address_street_line_2).to eq("")
-    expect(object.address_city).to eq("new york")
-    expect(object.address_state).to eq("NY")
-    expect(object.address_zip_code).to eq("10003")
-  end
-
-  it "persists and loads address object correctly" do
-    address = Flex::Address.new(street_line_1: "123 Main St", street_line_2: "Apt 4B", city: "Boston", state: "MA", zip_code: "02108")
-    object.address = address
-    object.save!
-
-    loaded_record = TestRecord.find(object.id)
-    expect(loaded_record.address).to be_a(Flex::Address)
-    expect(loaded_record.address).to eq(address)
-    expect(loaded_record.address_street_line_1).to eq("123 Main St")
-    expect(loaded_record.address_street_line_2).to eq("Apt 4B")
-    expect(loaded_record.address_city).to eq("Boston")
-    expect(loaded_record.address_state).to eq("MA")
-    expect(loaded_record.address_zip_code).to eq("02108")
-  end
-
-  describe "array: true" do
-    it "allows setting an array of addresses" do
-      addresses = [
-        build(:address, :base),
-        build(:address, :base)
-      ]
-      object.addresses = addresses
-
-      expect(object.addresses).to be_an(Array)
-      expect(object.addresses.size).to eq(2)
-      expect(object.addresses[0]).to eq(addresses[0])
-      expect(object.addresses[1]).to eq(addresses[1])
-    end
-
-    it "validates each address in the array" do
-      object.addresses = [
-        Flex::Address.new(street_line_1: "123 Main St", state: "MA", zip_code: "02108"), # Invalid: missing city
-        build(:address, :base) # Valid
-      ]
-
-      expect(object).not_to be_valid
-      expect(object.errors[:addresses]).to include("contains one or more invalid items")
-    end
-
-    it "persists and loads arrays of value objects" do
-      address_1 = build(:address, :base)
-      address_2 = build(:address, :base)
-      object.addresses = [ address_1, address_2 ]
-
-      object.save!
-      loaded_record = TestRecord.find(object.id)
-
-      expect(loaded_record.addresses.size).to eq(2)
-      expect(loaded_record.addresses[0]).to eq(address_1)
-      expect(loaded_record.addresses[1]).to eq(address_2)
-    end
-  end
+    },
+    array_values: [
+      FactoryBot.build(:address, :base),
+      FactoryBot.build(:address, :base, :with_street_line_2)
+    ],
+    invalid_value: FactoryBot.build(:address, :invalid)
 end
 # rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/lib/flex/attributes/name_attribute_spec.rb
+++ b/spec/lib/flex/attributes/name_attribute_spec.rb
@@ -1,84 +1,16 @@
 require "rails_helper"
+require_relative "value_object_attribute_shared_examples"
 
 RSpec.describe Flex::Attributes::NameAttribute do
-  let(:object) { TestRecord.new }
-  let(:first) { "Jane" }
-  let(:middle) { "Marie" }
-  let(:last) { "Doe" }
-
-  it "allows setting name as a value object" do
-    name = Flex::Name.new(first:, middle:, last:)
-    object.name = name
-
-    expect(object.name).to eq(Flex::Name.new(first:, middle:, last:))
-    expect(object.name_first).to eq(first)
-    expect(object.name_middle).to eq(middle)
-    expect(object.name_last).to eq(last)
-  end
-
-  it "allows setting name as a hash" do
-    object.name = { first: first, middle: middle, last: last }
-
-    expect(object.name).to eq(Flex::Name.new(first:, middle:, last:))
-    expect(object.name_first).to eq(first)
-    expect(object.name_middle).to eq(middle)
-    expect(object.name_last).to eq(last)
-  end
-
-  it "allows setting nested name attributes directly" do
-    object.name_first = first
-    object.name_middle = middle
-    object.name_last = last
-    expect(object.name).to eq(Flex::Name.new(first:, middle:, last:))
-  end
-
-  it "preserves values exactly as entered without normalization" do
-    object.name = { first: "jean-luc", middle: "von", last: "O'REILLY" }
-
-    expect(object.name).to eq(Flex::Name.new(first: "jean-luc", middle: "von", last: "O'REILLY"))
-    expect(object.name_first).to eq("jean-luc")
-    expect(object.name_middle).to eq("von")
-    expect(object.name_last).to eq("O'REILLY")
-  end
-
-  it "persists and loads name object correctly" do
-    name = Flex::Name.new(first: "John", middle: "Middle", last: "Doe")
-    object.name = name
-    object.save!
-
-    loaded_record = TestRecord.find(object.id)
-    expect(loaded_record.name).to be_a(Flex::Name)
-    expect(loaded_record.name).to eq(name)
-    expect(loaded_record.name_first).to eq("John")
-    expect(loaded_record.name_middle).to eq("Middle")
-    expect(loaded_record.name_last).to eq("Doe")
-  end
-
-  describe "array: true" do
-    it "allows setting an array of names" do
-      names = [
-        Flex::Name.new(first: "John", last: "Smith"),
-        Flex::Name.new(first: "Jane", middle: "Marie", last: "Doe")
-      ]
-      object.names = names
-
-      expect(object.names).to be_an(Array)
-      expect(object.names.size).to eq(2)
-      expect(object.names[0]).to eq(names[0])
-      expect(object.names[1]).to eq(names[1])
-    end
-
-    it "persists and loads arrays of value objects" do
-      name_1 = build(:name, :base)
-      name_2 = build(:name, :base, :with_middle)
-      object.names = [ name_1, name_2 ]
-
-      object.save!
-      loaded_record = TestRecord.find(object.id)
-
-      expect(loaded_record.names.size).to eq(2)
-      expect(loaded_record.names[0]).to eq(name_1)
-      expect(loaded_record.names[1]).to eq(name_2)
-    end
-  end
+  include_examples "value object shared examples", Flex::Name, :name,
+    valid_nested_attributes: FactoryBot.attributes_for(:name, :base, :with_middle),
+    nested_attributes_without_normalization: {
+      first: "jean-luc",
+      middle: "von",
+      last: "O'REILLY"
+    },
+    array_values: [
+      FactoryBot.build(:name, :base),
+      FactoryBot.build(:name, :base, :with_middle)
+    ]
 end

--- a/spec/lib/flex/attributes/value_object_attribute_shared_examples.rb
+++ b/spec/lib/flex/attributes/value_object_attribute_shared_examples.rb
@@ -1,0 +1,105 @@
+RSpec.shared_examples "value object shared examples" do |
+    value_class,
+    attribute,
+    valid_nested_attributes:,
+    invalid_value: nil,
+    nested_attributes_without_normalization: nil,
+    array_values: []
+  |
+  let(:object) { TestRecord.new }
+  valid_nested_attributes.each do |attr, value|
+    let(attr) { value }
+  end
+
+  it "allows setting #{attribute} as a value object" do
+    value_object = value_class.new(**valid_nested_attributes)
+    object.public_send("#{attribute}=", value_object)
+
+    expect(object.public_send(attribute)).to eq(value_class.new(**valid_nested_attributes))
+    valid_nested_attributes.each do |nested_attribute, value|
+      expect(object.public_send("#{attribute}_#{nested_attribute}")).to eq(value)
+    end
+  end
+
+  it "allows setting #{attribute} as a hash" do
+    object.public_send("#{attribute}=", valid_nested_attributes)
+
+    expect(object.public_send(attribute)).to eq(value_class.new(**valid_nested_attributes))
+    valid_nested_attributes.each do |nested_attribute, value|
+      expect(object.public_send("#{attribute}_#{nested_attribute}")).to eq(value)
+    end
+  end
+
+  it "allows setting nested #{attribute} attributes directly" do
+    valid_nested_attributes.each do |attr, value|
+      object.public_send("#{attribute}_#{attr}=", value)
+    end
+    expect(object.public_send(attribute)).to eq(value_class.new(**valid_nested_attributes))
+  end
+
+  if nested_attributes_without_normalization.present?
+    it "preserves values exactly as entered without normalization" do
+      object.public_send("#{attribute}=", nested_attributes_without_normalization)
+
+      expect(object.public_send(attribute)).to eq(value_class.new(**nested_attributes_without_normalization))
+      nested_attributes_without_normalization.each do |nested_attribute, value|
+        expect(object.public_send("#{attribute}_#{nested_attribute}")).to eq(value)
+      end
+    end
+  end
+
+  it "persists and loads #{attribute} object correctly" do
+    value_object = value_class.new(**valid_nested_attributes)
+    object.public_send("#{attribute}=", value_object)
+    object.save!
+
+    loaded_record = TestRecord.find(object.id)
+    expect(loaded_record.public_send(attribute)).to be_a(value_class)
+    expect(loaded_record.public_send(attribute)).to eq(value_object)
+    valid_nested_attributes.each do |nested_attribute, value|
+      expect(loaded_record.public_send("#{attribute}_#{nested_attribute}")).to eq(value)
+    end
+  end
+
+  if array_values.present?
+    describe "array: true" do
+      attribute_pluralized = "#{attribute.to_s.pluralize}"
+
+      it "allows setting an array of #{attribute_pluralized}" do
+        object.public_send("#{attribute_pluralized}=", array_values)
+
+        expect(object.public_send(attribute_pluralized)).to be_an(Array)
+        expect(object.public_send(attribute_pluralized).size).to eq(array_values.size)
+        expect(object.public_send(attribute_pluralized)).to eq(array_values)
+        array_values.each_with_index do |value, index|
+          expect(object.public_send(attribute_pluralized)[index]).to be_a(value_class)
+          expect(object.public_send(attribute_pluralized)[index]).to eq(value)
+        end
+      end
+
+      if invalid_value.present?
+        it "validates each #{attribute} in the array" do
+          object.public_send("#{attribute_pluralized}=", [ invalid_value, *array_values ])
+
+          expect(object).not_to be_valid
+          expect(object.errors[attribute_pluralized.to_sym]).to include("contains one or more invalid items")
+        end
+      end
+
+      it "persists and loads arrays of value objects" do
+        object.public_send("#{attribute_pluralized}=", array_values)
+
+        object.save!
+        loaded_record = TestRecord.find(object.id)
+
+        expect(loaded_record.public_send(attribute_pluralized)).to be_an(Array)
+        expect(loaded_record.public_send(attribute_pluralized).size).to eq(array_values.size)
+        expect(loaded_record.public_send(attribute_pluralized)).to eq(array_values)
+        array_values.each_with_index do |value, index|
+          expect(loaded_record.public_send(attribute_pluralized)[index]).to be_a(value_class)
+          expect(loaded_record.public_send(attribute_pluralized)[index]).to eq(value)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes

Extracted shared specs from value object attributes into a shared spec value_object_attribute_shared_examples.rb

## Context

from https://github.com/navapbc/flex-sdk/pull/153#discussion_r2222860897

## Testing

CI