### PR TITLE
Call constantize on string prior to .find call

### DIFF
--- a/app/models/flex/case.rb
+++ b/app/models/flex/case.rb
@@ -38,7 +38,7 @@ module Flex
     # Returns the application form class for this case class.
     # Subclasses can override this method to customize the application form class naming.
     def self.application_form_class
-      name.sub("Case", "ApplicationForm")
+      name.sub("Case", "ApplicationForm").constantize
     end
     attribute :application_form_id, :uuid
 


### PR DESCRIPTION
## Changes

Somehow these changes were made without the tests failing, but we are passing a string back as the class. We need to return it as a Ruby constant class name in order to call methods on it.
