### PR TITLE
Remove redundant main tag from tasks index

### DIFF
--- a/app/views/strata/tasks/index.html.erb
+++ b/app/views/strata/tasks/index.html.erb
@@ -14,87 +14,85 @@
   #
  %>
 <!-- Main content -->
-<main class="usa-section">
-  <div class="grid-container">
-    <h1 class="usa-heading-xl"><%= t("strata.tasks.index.title") %></h1>
-    <nav class="display-flex border-bottom-1px border-base-light">
-      <%
-        filter_params = params.permit(:filter_date, :filter_type, :filter_status)
-        [
-          {
-            name: t("strata.tasks.index.tabs.assigned"),
-            path: url_for(filter_params.merge(filter_status: nil)),
-            active: params[:filter_status] != "completed"
-          },
-          {
-            name: t("strata.tasks.index.tabs.completed"),
-            path: url_for(filter_params.merge(filter_status: "completed")),
-            active: params[:filter_status] == "completed"
-          }
-        ].each do |tab|
-      %>
-        <%= render partial: "strata/cases/nav_tab", locals: tab %>
-      <% end %>
-    </nav>
-    <!-- Filters -->
-    <div class="grid-row grid-gap-4 margin-bottom-4">
-      <div class="grid-col-12 tablet:grid-col-3">
-        <%= render partial: 'strata/tasks/type_filter', locals: { task_types: task_types } %>
-      </div>
-      <div class="grid-col-12 tablet:grid-col-3">
-        <%= render partial: 'strata/tasks/due_date_filter' %>
-      </div>
-      <div class="grid-col-12 tablet:grid-col-3">
-        <label class="usa-label" for="next-task-button" style="margin-bottom: 0.5rem">Actions:</label>
-        <%= button_to t("strata.tasks.actions.pick_next"), url_for(only_path: true, action: :pick_up_next_task),
-                        id: "next-task-button",
-                        disabled: !unassigned_tasks&.any?,
-                        method: :post,
-                        title: unassigned_tasks&.any? ? t("strata.tasks.messages.no_tasks_available") : nil,
-                        class: "usa-button" %>
-      </div>
-    </div>
-    <% if tasks&.any? %>
-      <!-- Tasks -->
-      <table class="usa-table usa-table--striped usa-table--sticky-header width-full">
-        <thead>
-          <tr>
-            <th data-sortable scope="col" role="columnheader" aria-sort="descending">
-              <%= t("strata.tasks.index.columns.col_due_date") %>
-            </th>
-            <th data-sortable scope="col" role="columnheader">
-              <%= t("strata.tasks.index.columns.col_type") %>
-            </th>
-            <th data-sortable scope="col" role="columnheader">
-              <%= t("strata.tasks.index.columns.col_case_id") %>
-            </th>
-            <th data-sortable scope="col" role="columnheader">
-              <%= t("strata.tasks.index.columns.col_created_date") %>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <% tasks.each do |task| %>
-            <tr>
-              <td data-sort-value="<%= time_since_epoch task.due_on %>">
-                <%= local_en_us task.due_on %>
-              </td>
-              <td data-sort-value="<%= task.type %>">
-                <%= link_to t("tasks.types.#{task.type.underscore}"), url_for(only_path: true, action: :show, id: task.id.to_s) %>
-              </td>
-              <td data-sort-value="<%= task.case_id %>">
-                <%= task.case_id %>
-              </td>
-              <td data-sort-value="<%= time_since_epoch task.created_at %>">
-                <%= local_en_us task.created_at.to_date %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-      <div class="usa-sr-only usa-table__announcement-region" aria-live="polite"></div>
-    <% else %>
-      <%= render partial: 'strata/tasks/no_tasks_alert' %>
+<div class="grid-container">
+  <h1 class="usa-heading-xl"><%= t("strata.tasks.index.title") %></h1>
+  <nav class="display-flex border-bottom-1px border-base-light">
+    <%
+      filter_params = params.permit(:filter_date, :filter_type, :filter_status)
+      [
+        {
+          name: t("strata.tasks.index.tabs.assigned"),
+          path: url_for(filter_params.merge(filter_status: nil)),
+          active: params[:filter_status] != "completed"
+        },
+        {
+          name: t("strata.tasks.index.tabs.completed"),
+          path: url_for(filter_params.merge(filter_status: "completed")),
+          active: params[:filter_status] == "completed"
+        }
+      ].each do |tab|
+    %>
+      <%= render partial: "strata/cases/nav_tab", locals: tab %>
     <% end %>
+  </nav>
+  <!-- Filters -->
+  <div class="grid-row grid-gap-4 margin-bottom-4">
+    <div class="grid-col-12 tablet:grid-col-3">
+      <%= render partial: 'strata/tasks/type_filter', locals: { task_types: task_types } %>
+    </div>
+    <div class="grid-col-12 tablet:grid-col-3">
+      <%= render partial: 'strata/tasks/due_date_filter' %>
+    </div>
+    <div class="grid-col-12 tablet:grid-col-3">
+      <label class="usa-label" for="next-task-button" style="margin-bottom: 0.5rem">Actions:</label>
+      <%= button_to t("strata.tasks.actions.pick_next"), url_for(only_path: true, action: :pick_up_next_task),
+                      id: "next-task-button",
+                      disabled: !unassigned_tasks&.any?,
+                      method: :post,
+                      title: unassigned_tasks&.any? ? t("strata.tasks.messages.no_tasks_available") : nil,
+                      class: "usa-button" %>
+    </div>
   </div>
-</main>
+  <% if tasks&.any? %>
+    <!-- Tasks -->
+    <table class="usa-table usa-table--striped usa-table--sticky-header width-full">
+      <thead>
+        <tr>
+          <th data-sortable scope="col" role="columnheader" aria-sort="descending">
+            <%= t("strata.tasks.index.columns.col_due_date") %>
+          </th>
+          <th data-sortable scope="col" role="columnheader">
+            <%= t("strata.tasks.index.columns.col_type") %>
+          </th>
+          <th data-sortable scope="col" role="columnheader">
+            <%= t("strata.tasks.index.columns.col_case_id") %>
+          </th>
+          <th data-sortable scope="col" role="columnheader">
+            <%= t("strata.tasks.index.columns.col_created_date") %>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <% tasks.each do |task| %>
+          <tr>
+            <td data-sort-value="<%= time_since_epoch task.due_on %>">
+              <%= local_en_us task.due_on %>
+            </td>
+            <td data-sort-value="<%= task.type %>">
+              <%= link_to t("tasks.types.#{task.type.underscore}"), url_for(only_path: true, action: :show, id: task.id.to_s) %>
+            </td>
+            <td data-sort-value="<%= task.case_id %>">
+              <%= task.case_id %>
+            </td>
+            <td data-sort-value="<%= time_since_epoch task.created_at %>">
+              <%= local_en_us task.created_at.to_date %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <div class="usa-sr-only usa-table__announcement-region" aria-live="polite"></div>
+  <% else %>
+    <%= render partial: 'strata/tasks/no_tasks_alert' %>
+  <% end %>
+</div>


### PR DESCRIPTION
## Changes

Removes `<main>` html tag from tasks index in order to fix inconsistent white space.

## Context

Partial resolves [TS-346](https://linear.app/nava-platform/issue/TSS-346/ui-design-updatesfixes)

Branched from https://github.com/navapbc/flex-sdk/pull/209

The tasks index is rednered within the staff layout, which contains a main tag, making the main within the index unnecessary. This duplicate tag, which is removed in this commit,  created additional white space between the navigation bar and the h1 header, leading to visual inconsistencies. Additionally, having only one main landmark improves accessibility for users navigating the page with a screen reader.


## Testing

The screen shots below show the changes to tasks index before and after `<main>` is removed from the tasks index.

**Before:**
<img width="1385" height="436" alt="Screenshot 2025-10-03 at 10 04 36 AM" src="https://github.com/user-attachments/assets/e99b0b3f-8941-4fb7-a418-eeeb23478d8d" />

**After:**
<img width="1331" height="369" alt="Screenshot 2025-10-03 at 10 05 08 AM" src="https://github.com/user-attachments/assets/d53196e5-385c-4a02-9641-b95a538d5f6d" />


