### PR TITLE
Update step indicator with header

### DIFF
--- a/app/views/strata/shared/_step_indicator.html.erb
+++ b/app/views/strata/shared/_step_indicator.html.erb
@@ -4,7 +4,6 @@
 # @param steps [Array<String, Symbol>] An array of step identifiers that will be displayed in order
 # @param current_step [String, Symbol] The identifier of the current active step
 # @param translation_scope [String] - I18n scope prefix, defaulting to 'strata.application_forms.steps'
-# @param show_header [Boolean] - Whether to show the "Step X of Y" header (default: true)
 #
 # Each step's display name is fetched from the i18n translations under strata.application_forms.steps
 # Steps before and including the current step are marked as complete.
@@ -13,7 +12,6 @@ steps = steps.map(&:to_sym)
 current_step = current_step.to_sym
 current_step_index = steps.index(current_step) || -1
 translation_scope ||= "strata.application_forms.steps"
-show_header = local_assigns.fetch(:show_header, true)
 
 step_indicators = steps.map.with_index do |step, index|
   {
@@ -55,16 +53,14 @@ step_indicator_class += "usa-step-indicator--counters" if local_assigns[:type] =
     <% end %>
   </ol>
   
-  <% if show_header %>
-    <div class="usa-step-indicator__header">
-      <h4 class="usa-step-indicator__heading">
-        <span class="usa-step-indicator__heading-counter">
-          <span class="usa-sr-only">Step</span>
-          <span class="usa-step-indicator__current-step"><%= current_step_index + 1 %></span>
-          <span class="usa-step-indicator__total-steps">of <%= steps.length %></span>
-        </span>
-        <span class="usa-step-indicator__heading-text"><%= current_step_name %></span>
-      </h4>
-    </div>
-  <% end %>
+  <div class="usa-step-indicator__header">
+    <h4 class="usa-step-indicator__heading">
+      <span class="usa-step-indicator__heading-counter">
+        <span class="usa-sr-only">Step</span>
+        <span class="usa-step-indicator__current-step"><%= current_step_index + 1 %></span>
+        <span class="usa-step-indicator__total-steps">of <%= steps.length %></span>
+      </span>
+      <span class="usa-step-indicator__heading-text"><%= current_step_name %></span>
+    </h4>
+  </div>
 </div>


### PR DESCRIPTION
## Changes
Added header to step indicator to match the USWDS step indicator spec 

## Context
The step indicator is part of the SDK and will be used in clients to display multi-step processes. 
Our goal is to be compliant with the USWDS standards and this requires not only a segment bar but also a header with X of Y step under the segment bar. 


## Testing

before :
<img width="1034" height="559" alt="Screenshot 2025-10-14 at 6 45 55 AM" src="https://github.com/user-attachments/assets/5a959946-7d9d-43fc-a05d-c0599c5e2f6c" />


after:
<img width="1070" height="617" alt="Screenshot 2025-10-14 at 6 44 30 AM" src="https://github.com/user-attachments/assets/a06c5fcf-65bc-4d71-b15b-2154a23a324d" />

