### PR TITLE
Make tasks controller setters protected instead of private

### DIFF
--- a/app/controllers/strata/tasks_controller.rb
+++ b/app/controllers/strata/tasks_controller.rb
@@ -44,6 +44,18 @@ module Strata
 
     protected
 
+    def set_task
+      @task = Strata::Task.find(params[:id]) if params[:id].present?
+    end
+
+    def set_case
+      @case = @task.case if @task.present?
+    end
+
+    def set_application_form
+      @application_form = @case.class.application_form_class.constantize.find(@case.application_form_id) if @case.present?
+    end
+
     def filter_tasks
       tasks = filter_tasks_by_date(Strata::Task.all, index_filter_params[:filter_date])
       tasks = filter_tasks_by_type(tasks, index_filter_params[:filter_type])
@@ -80,18 +92,6 @@ module Strata
     end
 
     private
-
-    def set_task
-      @task = Strata::Task.find(params[:id]) if params[:id].present?
-    end
-
-    def set_case
-      @case = @task.case if @task.present?
-    end
-
-    def set_application_form
-      @application_form = @case.class.application_form_class.constantize.find(@case.application_form_id) if @case.present?
-    end
 
     def add_task_details_view_path
       prepend_view_path "app/views/#{controller_path}"


### PR DESCRIPTION
## Changes

- Make `set_task`, `set_case`, and `set_application_form` `protected` instead of `private` in `TasksController` so that they can be used or overridden in children classes.

## Context

This will assist in completing TSS-342

## Testing

- CI
