### PR TITLE
Remove task details header and locales

### DIFF
--- a/app/views/strata/tasks/show.html.erb
+++ b/app/views/strata/tasks/show.html.erb
@@ -75,7 +75,6 @@
           </div>
         </div>
       <% end %>
-      <h2 class="section-heading-h2"><%= t("strata.tasks.show.headers.task_details") %></h2>
       <% if content_for?(:task_details_partial) %>
         <%= yield(:task_details_partial) %>
       <% else %>

--- a/config/locales/strata/en.yml
+++ b/config/locales/strata/en.yml
@@ -77,8 +77,6 @@ en:
           col_case_id: "Case ID"
           col_created_date: "Task created date"
       show:
-        headers:
-          task_details: "Task Details"
         details:
           status: "Task status:"
           due_on: "Due on:"

--- a/config/locales/strata/es-US.yml
+++ b/config/locales/strata/es-US.yml
@@ -71,8 +71,6 @@ es-US:
           col_case_id: "ID del caso"
           col_created_date: "Fecha de creación de la tarea"
       show:
-        headers:
-          task_details: "Detalles de la tarea"
         details:
           status: "Estado de la tarea:"
           due_on: "Fecha de vencimiento:"


### PR DESCRIPTION
## Changes

- Removed the "Task Details" subheader on the task show view

## Context

- Removing this as part of TSS-365, cleaning up the task view

## Testing

- Navigate to a task and ensure that "Task Details" is not present
