### PR TITLE
Add option to disable tile style

### DIFF
--- a/app/helpers/strata/form_builder.rb
+++ b/app/helpers/strata/form_builder.rb
@@ -93,6 +93,9 @@ module Strata
       label_text = options.delete(:label)
       label_options = { for: field_id(attribute, tag_value) }.merge(options)
 
+      tile = options.key?(:tile) ? options.delete(:tile) : true
+      append_to_option(options, :class, " usa-radio__input--tile") if tile
+
       @template.content_tag(:div, class: "usa-radio") do
         super(attribute, tag_value, options) + us_toggle_label("radio", attribute, label_text, label_options)
       end
@@ -569,7 +572,7 @@ module Strata
       when :file_field
         "usa-file-input"
       when :radio_button
-        "usa-radio__input usa-radio__input--tile"
+        "usa-radio__input"
       when :text_area
         "usa-textarea"
       else

--- a/spec/helpers/strata/form_builder_spec.rb
+++ b/spec/helpers/strata/form_builder_spec.rb
@@ -225,11 +225,24 @@ RSpec.describe Strata::FormBuilder do
       expect(result).to have_element(:input, type: 'radio', class: 'usa-radio__input', name: 'object[first_name]', value: 'yes')
     end
 
+    it 'defaults to tile style' do
+      expect(result).to have_element(:input, type: 'radio', class: 'usa-radio__input--tile')
+    end
+
     context 'with hint' do
       let(:result) { builder.radio_button(:first_name, 'yes', hint: 'Select yes') }
 
       it 'outputs a hint' do
         expect(result).to have_element(:span, text: 'Select yes', class: 'usa-radio__label-description')
+      end
+    end
+
+    context 'with tile option false' do
+      let(:result) { builder.radio_button(:first_name, 'yes', tile: false) }
+
+      it 'outputs a radio button without the tile class' do
+        expect(result).to have_element(:input, type: 'radio', class: 'usa-radio__input')
+        expect(result).not_to have_element(:input, type: 'radio', class: 'usa-radio__input--tile')
       end
     end
   end


### PR DESCRIPTION
## Changes

- Changed the Strata Form Builder, `radio_button` method, to allow disabling the tile style
    - See [USWDS documentation](https://designsystem.digital.gov/components/radio-buttons/#default) for information on the tile style vs. default style

## Context

- This is required so that I can complete TSS-365.

## Testing

- CI
