### PR TITLE
Add integer conversion to Strata::Money

### DIFF
--- a/app/models/strata/money.rb
+++ b/app/models/strata/money.rb
@@ -99,6 +99,13 @@ module Strata
       number_to_currency(dollar_amount)
     end
 
+    # Returns the amount as an Integer in cents
+    #
+    # @return [Integer] The cents amount
+    def to_i
+      cents
+    end
+
     # Comparison operator for Comparable
     #
     # @param [Money] other The other Money object to compare

--- a/spec/models/strata/money_spec.rb
+++ b/spec/models/strata/money_spec.rb
@@ -153,10 +153,16 @@ RSpec.describe Strata::Money do
   describe "#cents_amount" do
     let(:money) { described_class.new(cents: 1234) }
 
-
-
     it "returns amount as integer in cents" do
       expect(money.cents_amount).to eq(1234)
+    end
+  end
+
+  describe "#to_i" do
+    let(:money) { described_class.new(cents: rand(1..1_000_000)) }
+
+    it "returns amount as integer in cents" do
+      expect(money.to_i).to eq(money.cents_amount)
     end
   end
 


### PR DESCRIPTION
## Changes

- Added an integer conversion for the Strata::Money type

## Context

This will assist in the completion of TSS-414.

Helps solve a situation where I would want to use earned income as an integer value, such as:
<img width="756" height="223" alt="image" src="https://github.com/user-attachments/assets/a738ae4b-f93a-41b2-9539-2de04ae06796" />

## Testing

CI
