### PR TITLE
Change Determination to store array of reasons

### DIFF
--- a/app/models/concerns/strata/determinable.rb
+++ b/app/models/concerns/strata/determinable.rb
@@ -10,7 +10,7 @@ module Strata
   #   my_form = MyApplicationForm.new
   #   my_form.record_determination!(
   #     decision_method: :automated,
-  #     reason: "pregnant_member",
+  #     reasons: ["pregnant_member"],
   #     outcome: :automated_exemption,
   #     determined_at: Date.today,
   #     determination_data: ruleset.output_data.reasons
@@ -31,7 +31,7 @@ module Strata
     #
     # @param decision_method [String, Symbol] How the determination was made
     #   (attestation, automated, staff_review)
-    # @param reason [String] Why this determination was made
+    # @param reasons [Array<String>] Why this determination was made
     #   (e.g., pregnant_member, incarcerated, requirements_verification)
     # @param outcome [String, Symbol] Result of determination
     #   (e.g., automated_exemption, requirements_met, requirements_not_met)
@@ -42,10 +42,10 @@ module Strata
     #
     # @return [Strata::Determination] The created determination record
     # @raise [ActiveRecord::RecordInvalid] If the record fails validation
-    def record_determination!(decision_method:, reason:, outcome:, determination_data:, determined_at:, determined_by_id: nil)
+    def record_determination!(decision_method:, reasons:, outcome:, determination_data:, determined_at:, determined_by_id: nil)
       determinations.create!(
         decision_method:,
-        reason:,
+        reasons:,
         outcome:,
         determination_data:,
         determined_at:,

--- a/app/models/strata/determination.rb
+++ b/app/models/strata/determination.rb
@@ -12,7 +12,7 @@ module Strata
   # @example Recording an automated determination
   #   record.record_determination!(
   #     decision_method: :automated,
-  #     reason: "pregnant_member",
+  #     reasons: ["pregnant_member"],
   #     outcome: :automated_exemption,
   #     determination_data: RulesEngine.new.evaluate(:pregnant_member).reasons
   #   )
@@ -20,7 +20,7 @@ module Strata
   # @example Recording a staff-reviewed determination
   #   record.record_determination!(
   #     decision_method: :staff_review,
-  #     reason: "requirements_verification",
+  #     reasons: ["requirements_verification"],
   #     outcome: :requirements_met,
   #     determination_data: RulesEngine.new.evaluate(:requirements_verification).reasons,
   #     determined_by_id: staff_uuid
@@ -32,7 +32,7 @@ module Strata
     belongs_to :subject, polymorphic: true, optional: false
 
     # Validations
-    validates :decision_method, :reason, :outcome, :determination_data, :determined_at, presence: true
+    validates :decision_method, :reasons, :outcome, :determination_data, :determined_at, presence: true
 
     # Query scopes for filtering determinations
 
@@ -56,7 +56,7 @@ module Strata
     }
     scope :with_reason, lambda { |reason_or_reasons|
       reasons = Array(reason_or_reasons).map(&:to_s)
-      where(reason: reasons)
+      where("reasons && ARRAY[?]::varchar[]", reasons)
     }
     scope :with_outcome, lambda { |outcome_or_outcomes|
       outcomes = Array(outcome_or_outcomes).map(&:to_s)

--- a/lib/generators/strata/determination/templates/create_strata_determinations.rb.tt
+++ b/lib/generators/strata/determination/templates/create_strata_determinations.rb.tt
@@ -9,7 +9,7 @@ class CreateStrataDeterminations < ActiveRecord::Migration[7.2]
 
       # Decision metadata
       t.string :decision_method, null: false    # :automated, :staff_review, :attestation
-      t.string :reason, null: false             # why the determination was made
+      t.string :reasons, array: true, default: [], null: false  # array of reasons for the determination
       t.string :outcome, null: false            # result of the determination
 
       # Supporting data (e.g., rules engine output)

--- a/lib/generators/strata/determination/templates/determinable.rb.tt
+++ b/lib/generators/strata/determination/templates/determinable.rb.tt
@@ -17,7 +17,7 @@
 # @example Record an automated determination
 #   record.record_determination!(
 #     decision_method: :automated,
-#     reason: "pregnant_member",
+#     reasons: ["pregnant_member"],
 #     outcome: :automated_exemption,
 #     determination_data: rules_engine.evaluate(:pregnant_member).reasons,
 #     determined_at: Time.current
@@ -26,7 +26,7 @@
 # @example Record a staff-reviewed determination
 #   record.record_determination!(
 #     decision_method: :staff_review,
-#     reason: "requirements_verification",
+#     reasons: ["requirements_verification"],
 #     outcome: :requirements_met,
 #     determination_data: {verified_fields: [:income, :address]},
 #     determined_at: Time.current,

--- a/lib/generators/strata/determination/templates/determination.rb.tt
+++ b/lib/generators/strata/determination/templates/determination.rb.tt
@@ -4,7 +4,7 @@
 #
 # By default, Strata::Determination provides:
 # - A polymorphic +subject+ association to any aggregate root
-# - Validations for all required fields (+decision_method+, +reason+, +outcome+, +determination_data+, +determined_at+)
+# - Validations for all required fields (+decision_method+, +reasons+, +outcome+, +determination_data+, +determined_at+)
 # - Query scopes for filtering by subject, decision method, reason, outcome, user, and time windows
 # - Support for automated, staff-reviewed, and attested determinations
 #
@@ -19,7 +19,7 @@
 #     enum decision_method: { automated: "automated", staff_review: "staff_review", attestation: "attestation" }
 #     enum outcome: { approved: "approved", denied: "denied", pending: "pending" }
 #
-#     validates :reason, inclusion: { in: %w(pregnant_member incarcerated other) }
+#     validates :reasons, inclusion: { in: %w(pregnant_member incarcerated other) }
 #   end
 #
 # @example Query determinations for a specific subject

--- a/spec/dummy/db/migrate/20251031212542_update_determinations_table.rb
+++ b/spec/dummy/db/migrate/20251031212542_update_determinations_table.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class UpdateDeterminationsTable < ActiveRecord::Migration[8.0]
+  def up
+    # Add the new reasons column as an array of strings
+    add_column :strata_determinations, :reasons, :string, array: true, default: [], null: false
+
+    # Copy existing reason values into reasons array
+    execute <<~SQL
+      UPDATE strata_determinations
+      SET reasons = ARRAY[reason]
+      WHERE reason IS NOT NULL AND reason != ''
+    SQL
+
+    # Remove the old reason column
+    remove_column :strata_determinations, :reason
+  end
+
+  def down
+    # Add back the old reason column
+    add_column :strata_determinations, :reason, :string, null: false, default: ""
+
+    # Copy first reason from array back to reason column
+    execute <<~SQL
+      UPDATE strata_determinations
+      SET reason = reasons[1]
+      WHERE array_length(reasons, 1) >= 1
+    SQL
+
+    # Remove the reasons column
+    remove_column :strata_determinations, :reasons
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_28_072830) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_31_212542) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -49,12 +49,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_28_072830) do
     t.uuid "subject_id", null: false
     t.string "subject_type", null: false
     t.string "decision_method", null: false
-    t.string "reason", null: false
     t.string "outcome", null: false
     t.jsonb "determination_data", default: {}, null: false
     t.uuid "determined_by_id"
     t.datetime "determined_at", null: false
     t.datetime "created_at", null: false
+    t.string "reasons", default: [], null: false, array: true
     t.index ["created_at"], name: "index_strata_determinations_on_created_at"
     t.index ["determined_at"], name: "index_strata_determinations_on_determined_at"
     t.index ["determined_by_id"], name: "index_strata_determinations_on_determined_by_id"

--- a/spec/factories/strata/strata_determination_factory.rb
+++ b/spec/factories/strata/strata_determination_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :strata_determination, class: 'Strata::Determination' do
     association :subject, factory: :test_application_form
     decision_method { :automated }
-    reason { "age_under_19" }
+    reasons { [ "age_under_19" ] }
     outcome { :automated_exemption }
     determination_data { { date_of_birth: "placeholder", evaluated_on: "placeholder" } }
     determined_by_id { nil }

--- a/spec/models/concerns/strata/determinable_spec.rb
+++ b/spec/models/concerns/strata/determinable_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Strata::Determinable do
         expect {
           test_form.record_determination!(
             decision_method: :automated,
-            reason: "pregnant_member",
+            reasons: [ "pregnant_member" ],
             outcome: :automated_exemption,
             determined_at: determined_at,
             determination_data: data
@@ -34,7 +34,7 @@ RSpec.describe Strata::Determinable do
 
         determination = test_form.determinations.first
         expect(determination.decision_method).to eq('automated')
-        expect(determination.reason).to eq('pregnant_member')
+        expect(determination.reasons).to eq([ "pregnant_member" ])
         expect(determination.outcome).to eq('automated_exemption')
         expect(determination.determination_data).to eq(data)
         expect(determination.determined_by_id).to be_nil
@@ -46,7 +46,7 @@ RSpec.describe Strata::Determinable do
       expect {
         test_form.record_determination!(
           decision_method: :automated,
-          reason: "test",
+          reasons: [ "test" ],
           outcome: :automated_exemption
           # missing determination_data
         )
@@ -57,7 +57,7 @@ RSpec.describe Strata::Determinable do
       expect {
         test_form.record_determination!(
           decision_method: :automated,
-          reason: "test",
+          reasons: [ "test" ],
           outcome: :automated_exemption,
           determination_data: {}
         )


### PR DESCRIPTION
## Changes

A determination will now store an array of reasons.

## Context

While working with determinations, a person could have many reasons that factor into a determination. A determination is also immutable, and the intention is for a determination to supersede a previous one on the aggregate root. This was discussed with team members on October 31st, 2025.

