### PR TITLE
Update create_strata_tasks.rb.tt

### DIFF
--- a/lib/generators/strata/task/templates/create_strata_tasks.rb.tt
+++ b/lib/generators/strata/task/templates/create_strata_tasks.rb.tt
@@ -8,6 +8,7 @@ class CreateStrataTasks < ActiveRecord::Migration[<%= ActiveRecord::Migration.cu
       t.integer :status, index: true, default: 0
       t.uuid :assignee_id, index: true # not linked to anything yet but will be later
       t.uuid :case_id, index: true
+      t.string :case_type
       t.date :due_on
 
       t.timestamps


### PR DESCRIPTION
Changes
Added case_type column to the strata_tasks table migration template in the task generator. The generator now creates migrations with the case_type column required for the polymorphic association.
Context
The Strata::Task model uses belongs_to :case, polymorphic: true, which requires both case_id and case_type. The generator’s migration template was missing case_type, causing migrations to be incomplete. This ensures new migrations include the required column.