### PR TITLE
Add on_hold status to Task enum

### DIFF
--- a/app/models/strata/task.rb
+++ b/app/models/strata/task.rb
@@ -30,7 +30,7 @@ module Strata
     protected attr_writer :assignee_id
 
     attribute :status, :integer, default: 0
-    enum :status, pending: 0, completed: 1
+    enum :status, pending: 0, completed: 1, on_hold: 2
 
     belongs_to :case, polymorphic: true
     validates :case, presence: true
@@ -74,7 +74,7 @@ module Strata
     private
 
     def publish_status_changed_event
-      Strata::EventManager.publish("#{self.class.name}#{status.capitalize}", { task_id: id, case_id: case_id })
+      Strata::EventManager.publish("#{self.class.name}#{status.camelize}", { task_id: id, case_id: case_id })
     end
   end
 end

--- a/spec/dummy/app/views/tasks/show.html.erb
+++ b/spec/dummy/app/views/tasks/show.html.erb
@@ -2,7 +2,7 @@
     task: @task,
     application_form: @application_form,
     task_info: [
-      { label: "Status:", value: @task.status.capitalize },
+      { label: "Status:", value: @task.status.camelize },
       { label: "Due On:", value: local_en_us(@task.due_on) },
       { label: "Assigned To:", value: @assignee&.full_name || link_to("Assign to me", "#", class: "usa-button") }
     ]

--- a/spec/models/strata/task_spec.rb
+++ b/spec/models/strata/task_spec.rb
@@ -114,6 +114,22 @@ RSpec.describe Strata::Task, type: :model do
         expect { task.pending! }.to publish_event_with_payload("Strata::TaskPending", { task_id: task.id, case_id: task.case_id })
       end
     end
+
+    describe '#on_hold' do
+      it 'marks the task as on hold' do
+        task.on_hold!
+        task.reload
+
+        expect(task.status).to eq('on_hold')
+        expect(task.on_hold?).to be true
+      end
+
+      it 'emits an event as on hold' do
+        task.pending! # Set it to pending first to ensure a status change
+
+        expect { task.on_hold! }.to publish_event_with_payload("Strata::TaskOnHold", { task_id: task.id, case_id: task.case_id })
+      end
+    end
   end
 
   describe 'validations' do


### PR DESCRIPTION
  - Add on_hold (value: 2) to task status enum
  - Change capitalize to camelize for multi-word status handling
  - Add specs for on_hold status transitions and events
  - Update task view to use camelize for status display


