### PR TITLE
Enable Style/RedundantSelf RuboCop cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,3 +60,5 @@ Style/Documentation:
 
 Style/FrozenStringLiteralComment:
   Enabled: true
+Style/RedundantSelf:
+  Enabled: true

--- a/app/components/strata/cases/case_row_component.rb
+++ b/app/components/strata/cases/case_row_component.rb
@@ -57,7 +57,7 @@ module Strata
       end
 
       def self.headers
-        self.columns.map { |column| t(".#{column}") }
+        columns.map { |column| t(".#{column}") }
       end
 
       protected

--- a/app/helpers/strata/form_builder.rb
+++ b/app/helpers/strata/form_builder.rb
@@ -24,8 +24,8 @@ module Strata
     # @param args [Array] Arguments passed to the parent FormBuilder constructor
     def initialize(*args)
       super
-      self.options[:html] ||= {}
-      self.options[:html][:class] ||= "usa-form usa-form--large"
+      options[:html] ||= {}
+      options[:html][:class] ||= "usa-form usa-form--large"
     end
 
     ########################################

--- a/app/models/strata/application_form.rb
+++ b/app/models/strata/application_form.rb
@@ -100,12 +100,12 @@ module Strata
 
     def publish_created
       Rails.logger.debug "Publishing event #{self.class.name}Created for application with ID: #{id}"
-      Strata::EventManager.publish("#{self.class.name}Created", self.event_payload)
+      Strata::EventManager.publish("#{self.class.name}Created", event_payload)
     end
 
     def publish_submitted
       Rails.logger.debug "Publishing event #{self.class.name}Submitted for application with ID: #{id}"
-      Strata::EventManager.publish("#{self.class.name}Submitted", self.event_payload)
+      Strata::EventManager.publish("#{self.class.name}Submitted", event_payload)
     end
   end
 end

--- a/app/models/strata/business_process.rb
+++ b/app/models/strata/business_process.rb
@@ -61,7 +61,7 @@ module Strata
     include BusinessProcessBuilder
 
     def self.case_class
-      self.name.sub("BusinessProcess", "Case").constantize
+      name.sub("BusinessProcess", "Case").constantize
     end
 
     def self.get_step(name)

--- a/app/services/strata/task_service.rb
+++ b/app/services/strata/task_service.rb
@@ -30,15 +30,15 @@ module Strata
     # @note Currently defaults to {Strata::TaskService::Database} if no service is set.
     #   Future versions may determine the service based on environment configuration.
     def self.get
-      if self.service.nil?
+      if service.nil?
         # Other ideas for adapters: asana, jira, salesforce, trello
         # In the future, we can determine the task service based on the environment
         # e.g. something like task_service_name = ENV["TASK_SERVICE"] || "Strata::TaskService::Database"
         # self.service = task_service_name.constantize.new
-        self.set(Strata::TaskService::Database.new)
+        set(Strata::TaskService::Database.new)
       end
 
-      self.service
+      service
     end
   end
 end


### PR DESCRIPTION
Enables the `Style/RedundantSelf` cop in `RuboCop` configuration and removes redundant `self` references.

This cop helps maintain cleaner, more idiomatic Ruby code by flagging unnecessary uses of `self`. In Ruby, explicit `self` is only required when calling setter methods or disambiguating in specific contexts. Removing redundant self references reduces visual noise and aligns with Ruby community style conventions.

References:
https://docs.rubocop.org/rubocop/cops_style.html#styleredundantself 
https://rubystyle.guide/#no-self-unless-required

