### PR TITLE
Add rbenv install step to make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ RAILS_CMD := cd spec/dummy && bundle exec rails
 
 install:
 	npm install --prefix spec/dummy
+	rbenv install --skip-existing
 	bundle install
 
 spec/dummy/.env: spec/dummy/local.env.example


### PR DESCRIPTION
## Changes

Adds a step in `make install` to run `rbenv install` to install Ruby.

## Context

`make setup` doesn't install Ruby. `--skip-existing` skips installing if already installed.

## Testing
<img width="479" height="208" alt="Screenshot 2026-02-18 at 4 26 25 PM" src="https://github.com/user-attachments/assets/61b99b87-20a8-4a95-bde3-68b356829873" />


