### PR TITLE
Add yield :head extension point to SDK layouts

### DIFF
--- a/app/views/layouts/strata/application.html.erb
+++ b/app/views/layouts/strata/application.html.erb
@@ -6,6 +6,7 @@
   <%= csp_meta_tag %>
 
   <%= stylesheet_link_tag    "application", media: "all" %>
+  <%= yield :head if content_for?(:head) %>
 </head>
 <body>
 

--- a/app/views/layouts/strata/staff.html.erb
+++ b/app/views/layouts/strata/staff.html.erb
@@ -7,6 +7,7 @@
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "application" %>
     <%= javascript_include_tag '@uswds/uswds/dist/js/uswds-init.min.js' %>
+    <%= yield :head if content_for?(:head) %>
   </head>
   <body>
     <div class="display-flex flex-column minh-viewport">

--- a/spec/dummy/app/controllers/layout_test_controller.rb
+++ b/spec/dummy/app/controllers/layout_test_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Test controller for verifying layout yield :head functionality
+class LayoutTestController < ApplicationController
+  helper_method :header_links
+
+  def staff_layout_without_head
+    render layout: "strata/staff"
+  end
+
+  def staff_layout_with_head
+    render layout: "strata/staff"
+  end
+
+  def application_layout_without_head
+    render layout: "strata/application"
+  end
+
+  def application_layout_with_head
+    render layout: "strata/application"
+  end
+
+  private
+
+  def header_links
+    # Provide minimal header_links for staff layout compatibility
+    []
+  end
+end

--- a/spec/dummy/app/views/layout_test/application_layout_with_head.html.erb
+++ b/spec/dummy/app/views/layout_test/application_layout_with_head.html.erb
@@ -1,0 +1,7 @@
+<% content_for :head do %>
+  <meta name="test-injected" content="application-custom-head">
+  <script>console.log('Custom application head content');</script>
+<% end %>
+
+<h1>Application Layout Test - With Custom Head</h1>
+<p>This view provides content_for :head</p>

--- a/spec/dummy/app/views/layout_test/application_layout_without_head.html.erb
+++ b/spec/dummy/app/views/layout_test/application_layout_without_head.html.erb
@@ -1,0 +1,2 @@
+<h1>Application Layout Test - No Custom Head</h1>
+<p>This view does not provide content_for :head</p>

--- a/spec/dummy/app/views/layout_test/staff_layout_with_head.html.erb
+++ b/spec/dummy/app/views/layout_test/staff_layout_with_head.html.erb
@@ -1,0 +1,7 @@
+<% content_for :head do %>
+  <meta name="test-injected" content="staff-custom-head">
+  <script>console.log('Custom staff head content');</script>
+<% end %>
+
+<h1>Staff Layout Test - With Custom Head</h1>
+<p>This view provides content_for :head</p>

--- a/spec/dummy/app/views/layout_test/staff_layout_without_head.html.erb
+++ b/spec/dummy/app/views/layout_test/staff_layout_without_head.html.erb
@@ -1,0 +1,2 @@
+<h1>Staff Layout Test - No Custom Head</h1>
+<p>This view does not provide content_for :head</p>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -44,4 +44,12 @@ Rails.application.routes.draw do
   end
 
   get "staff", to: "staff#index"
+
+  # Test routes for layout yield :head verification (test environment only)
+  if Rails.env.test?
+    get "layout_test/staff_layout_without_head"
+    get "layout_test/staff_layout_with_head"
+    get "layout_test/application_layout_without_head"
+    get "layout_test/application_layout_with_head"
+  end
 end

--- a/spec/dummy/spec/requests/layout_head_injection_spec.rb
+++ b/spec/dummy/spec/requests/layout_head_injection_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "Layout head injection", type: :request do
+  describe "strata/staff layout" do
+    context "when view does not provide content_for :head" do
+      it "renders successfully without errors" do
+        get "/layout_test/staff_layout_without_head"
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "does not include custom head content" do
+        get "/layout_test/staff_layout_without_head"
+        expect(response.body).not_to include('test-injected')
+        expect(response.body).not_to include('Custom staff head content')
+      end
+
+      it "includes standard head elements" do
+        get "/layout_test/staff_layout_without_head"
+
+        # Should have standard meta tags
+        expect(response.body).to include('<meta name="viewport"')
+
+        # Should have standard scripts (with asset pipeline digest)
+        expect(response.body).to match(/uswds-init\.min.*\.js/)
+      end
+    end
+
+    context "when view provides content_for :head" do
+      it "renders successfully" do
+        get "/layout_test/staff_layout_with_head"
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "includes the custom head content" do
+        get "/layout_test/staff_layout_with_head"
+
+        # Should include custom meta tag
+        expect(response.body).to include('<meta name="test-injected" content="staff-custom-head">')
+
+        # Should include custom script
+        expect(response.body).to include("console.log('Custom staff head content');")
+      end
+
+      it "injects content inside <head> tags" do
+        get "/layout_test/staff_layout_with_head"
+
+        # Extract just the head section
+        head_section = response.body.match(/<head>(.*?)<\/head>/m)[1]
+
+        # Custom content should be in the head
+        expect(head_section).to include('test-injected')
+        expect(head_section).to include('Custom staff head content')
+      end
+
+      it "includes both standard and custom head elements" do
+        get "/layout_test/staff_layout_with_head"
+
+        # Should have standard elements (with asset pipeline digest)
+        expect(response.body).to match(/uswds-init\.min.*\.js/)
+
+        # Should have custom elements
+        expect(response.body).to include('test-injected')
+      end
+    end
+  end
+
+  describe "strata/application layout" do
+    context "when view does not provide content_for :head" do
+      it "renders successfully without errors" do
+        get "/layout_test/application_layout_without_head"
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "does not include custom head content" do
+        get "/layout_test/application_layout_without_head"
+        expect(response.body).not_to include('test-injected')
+        expect(response.body).not_to include('Custom application head content')
+      end
+
+      it "includes standard head elements" do
+        get "/layout_test/application_layout_without_head"
+
+        # Should have standard elements
+        expect(response.body).to include('<title>Strata</title>')
+        expect(response.body).to include('<head>')
+      end
+    end
+
+    context "when view provides content_for :head" do
+      it "renders successfully" do
+        get "/layout_test/application_layout_with_head"
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "includes the custom head content" do
+        get "/layout_test/application_layout_with_head"
+
+        # Should include custom meta tag
+        expect(response.body).to include('<meta name="test-injected" content="application-custom-head">')
+
+        # Should include custom script
+        expect(response.body).to include("console.log('Custom application head content');")
+      end
+
+      it "injects content inside <head> tags" do
+        get "/layout_test/application_layout_with_head"
+
+        # Extract just the head section
+        head_section = response.body.match(/<head>(.*?)<\/head>/m)[1]
+
+        # Custom content should be in the head
+        expect(head_section).to include('test-injected')
+        expect(head_section).to include('Custom application head content')
+      end
+
+      it "includes both standard and custom head elements" do
+        get "/layout_test/application_layout_with_head"
+
+        # Should have standard elements
+        expect(response.body).to include('<title>Strata</title>')
+
+        # Should have custom elements
+        expect(response.body).to include('test-injected')
+      end
+    end
+  end
+
+  describe "real-world use case: importmap injection" do
+    it "can inject javascript_importmap_tags into staff layout" do
+      # This simulates what OSCER needs to do
+      get "/layout_test/staff_layout_with_head"
+
+      # The test view includes a script tag - verify it renders in head
+      head_section = response.body.match(/<head>(.*?)<\/head>/m)[1]
+      expect(head_section).to include('<script>')
+    end
+
+    it "can inject javascript_importmap_tags into application layout" do
+      # This simulates what any host app might need
+      get "/layout_test/application_layout_with_head"
+
+      # The test view includes a script tag - verify it renders in head
+      head_section = response.body.match(/<head>(.*?)<\/head>/m)[1]
+      expect(head_section).to include('<script>')
+    end
+  end
+end


### PR DESCRIPTION
Add `<%= yield :head if content_for?(:head) %>` to both strata/staff and strata/application layouts. This allows host apps to inject custom tags into <head> (e.g., javascript_importmap_tags) without overriding the entire layout file.

This eliminates the need for OSCER (and future host apps) to maintain full copies of SDK layouts just to add framework-specific head tags, reducing drift risk when SDK layouts are updated.

Includes request specs covering:
- Layouts render correctly with and without content_for :head
- Custom content appears inside <head> tags
- Standard layout elements remain intact
- Real-world importmap injection use case