### PR TITLE
[Conditional Field] Include buttons in enable/disable sweep

### DIFF
--- a/app/components/strata/conditional_field_component_controller.js
+++ b/app/components/strata/conditional_field_component_controller.js
@@ -65,13 +65,13 @@ export default class extends Controller {
   }
 
   enableInputs() {
-    this.element.querySelectorAll("input, select, textarea").forEach((input) => {
+    this.element.querySelectorAll("input, select, textarea, button").forEach((input) => {
       input.disabled = false
     })
   }
 
   disableInputs() {
-    this.element.querySelectorAll("input, select, textarea").forEach((input) => {
+    this.element.querySelectorAll("input, select, textarea, button").forEach((input) => {
       input.disabled = true
     })
   }


### PR DESCRIPTION
## Changes

Adds `button` to the list of elements that the conditional field component's Stimulus controller enables/disables when toggling visibility.

Before:

```js
this.element.querySelectorAll("input, select, textarea")
```

After:

```js
this.element.querySelectorAll("input, select, textarea, button")
```

## Context

When a conditional field starts hidden, its input elements are disabled so they don't get submitted with the form. If a USWDS date picker is inside that wrapper, USWDS notices the disabled input when it attaches and also disables the calendar button it adds. When the user later clicks the radio to show the section, our re-enable pass only covered inputs/selects/textareas, so the USWDS calendar button stayed disabled and clicking it did nothing.

Adding `button` to the sweep lets `show()` re-enable the calendar button (and any other button nested in the wrapper) alongside the form fields.

## Testing

Verified on the strata-paidleave PR environment at `/lookbook/inspect/applicants/leave_applications/employment_details/default`: clicked "Yes" under "Have you told this employer...", then clicked the calendar icon — calendar dropdown opens correctly.

Companion PR (keeps the test deploy wired up): navapbc/strata-paidleave#109

<img width="1304" height="1264" alt="Screenshot 2026-04-18 at 1 54 22 PM" src="https://github.com/user-attachments/assets/34169df3-641d-4f53-935f-42be76ec0c52" />

https://github.com/user-attachments/assets/fa8cfc1a-e08c-4999-8a86-71e4e8c5f9fd

