### PR TITLE
Remove messages when running tests

### DIFF
--- a/app/models/strata/flows/application_form_controller.rb
+++ b/app/models/strata/flows/application_form_controller.rb
@@ -72,7 +72,7 @@ module Strata::Flows
                 flash.now[:errors] = flow_record.errors.full_messages
               end
 
-              render page.edit_pathname, status: :unprocessable_entity
+              render page.edit_pathname, status: :unprocessable_content
             end
           end
         end

--- a/lib/generators/strata/staff/staff_generator.rb
+++ b/lib/generators/strata/staff/staff_generator.rb
@@ -44,6 +44,8 @@ module Strata
       end
 
       def print_next_steps
+        return if options[:quiet]
+
         say "\n" + set_color("Next Steps:", :green, :bold)
         say "  1. Customize the case_classes method in app/controllers/staff_controller.rb"
         say "     Example: def case_classes; [MyCase, AnotherCase]; end"

--- a/spec/dummy/app/controllers/passport_application_forms_controller.rb
+++ b/spec/dummy/app/controllers/passport_application_forms_controller.rb
@@ -27,7 +27,7 @@ class PassportApplicationFormsController < ApplicationController
           return
         else
           flash.now[:errors] = @passport_application_form.errors.full_messages
-          render :edit, status: :unprocessable_entity
+          render :edit, status: :unprocessable_content
           return
         end
       end
@@ -35,7 +35,7 @@ class PassportApplicationFormsController < ApplicationController
       redirect_to @passport_application_form, notice: "Passport application form was successfully updated."
     else
       flash.now[:errors] = @passport_application_form.errors.full_messages
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 
@@ -49,7 +49,7 @@ class PassportApplicationFormsController < ApplicationController
           return
         else
           flash.now[:errors] = @passport_application_form.errors.full_messages
-          render :new, status: :unprocessable_entity
+          render :new, status: :unprocessable_content
           return
         end
       end
@@ -57,7 +57,7 @@ class PassportApplicationFormsController < ApplicationController
       redirect_to @passport_application_form, notice: "Passport application form was successfully saved."
     else
       flash.now[:errors] = @passport_application_form.errors.full_messages
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 

--- a/spec/dummy/app/controllers/sample_application_forms_controller.rb
+++ b/spec/dummy/app/controllers/sample_application_forms_controller.rb
@@ -22,7 +22,7 @@ class SampleApplicationFormsController < ApplicationController
       redirect_to @sample_application_form
     else
       flash.now[:errors] = @sample_application_form.errors.full_messages
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -34,7 +34,7 @@ class SampleApplicationFormsController < ApplicationController
       redirect_to sample_application_form_path(@sample_application_form)
     elsif @sample_application_form.errors.full_messages
       flash.now[:errors] = @sample_application_form.errors.full_messages
-      render :review, status: :unprocessable_entity
+      render :review, status: :unprocessable_content
     else
       raise StandardError.new("The application could not be submitted.")
     end

--- a/spec/dummy/app/previews/sample_task_list_preview.rb
+++ b/spec/dummy/app/previews/sample_task_list_preview.rb
@@ -26,14 +26,14 @@ class SampleTaskListPreview < Lookbook::Preview
   end
 
   # @label No tasks completed
-  # @notes Only the first task (Personal Information) is startable. Employment Details and Leave Details show "Cannot start yet" because their dependencies are not met.
+  # @note Only the first task (Personal Information) is startable. Employment Details and Leave Details show "Cannot start yet" because their dependencies are not met.
   def depends_on_no_tasks_completed
     flow = SampleFlow.new(FactoryBot.build_stubbed(:sample_application_form))
     render Strata::Flows::TaskListComponent.new(flow:, show_step_label: true)
   end
 
   # @label First task completed
-  # @notes Personal Information is completed, unlocking Employment Details. Leave Details still shows "Cannot start yet" because it depends on Employment Details.
+  # @note Personal Information is completed, unlocking Employment Details. Leave Details still shows "Cannot start yet" because it depends on Employment Details.
   def depends_on_first_task_completed
     flow = SampleFlow.new(FactoryBot.build_stubbed(
       :sample_application_form,
@@ -44,7 +44,7 @@ class SampleTaskListPreview < Lookbook::Preview
   end
 
   # @label Two tasks completed
-  # @notes Personal Information and Employment Details are completed, unlocking Leave Details.
+  # @note Personal Information and Employment Details are completed, unlocking Leave Details.
   def depends_on_two_tasks_completed
     flow = SampleFlow.new(FactoryBot.build_stubbed(
       :sample_application_form,
@@ -56,7 +56,7 @@ class SampleTaskListPreview < Lookbook::Preview
   end
 
   # @label All tasks completed
-  # @notes All tasks are completed and show the "Completed" status with edit links.
+  # @note All tasks are completed and show the "Completed" status with edit links.
   def depends_on_all_tasks_completed
     flow = SampleFlow.new(FactoryBot.build_stubbed(:sample_application_form, :submittable))
     render Strata::Flows::TaskListComponent.new(flow:, show_step_label: true)

--- a/spec/dummy/spec/controllers/sample_application_forms/sample_application_forms_controller_name_spec.rb
+++ b/spec/dummy/spec/controllers/sample_application_forms/sample_application_forms_controller_name_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe SampleApplicationFormsController do
 
       it "returns unprocessable entity status" do
         patch :update_name, params: invalid_params
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/spec/dummy/spec/requests/passport_application_forms_spec.rb
+++ b/spec/dummy/spec/requests/passport_application_forms_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "PassportApplicationForms", type: :request do
       allow(passport_application_form).to receive(:update).and_return(false)
       patch "/passport_application_forms/#{passport_application_form.id}",
             params: { passport_application_form: { name_first: "" } }
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
     end
   end
 end

--- a/spec/lib/generators/strata/generators/staff_generator_spec.rb
+++ b/spec/lib/generators/strata/generators/staff_generator_spec.rb
@@ -7,7 +7,7 @@ require 'tmpdir'
 
 RSpec.describe Strata::Generators::StaffGenerator, type: :generator do
   let(:destination_root) { Dir.mktmpdir }
-  let(:generator) { described_class.new([], {}, destination_root: destination_root) }
+  let(:generator) { described_class.new([], { quiet: true }, destination_root: destination_root) }
 
   before do
     FileUtils.mkdir_p("#{destination_root}/app/controllers")


### PR DESCRIPTION
## Changes

- Changed usage of `unprocessable_entity` to instead use the recommended `unprocessable_content`
- Added a `quiet` option to the staff generator so that it doesn't have to output text
- Renamed `@notes` to `@note` in a Lookbook preview file to align with supported documentation

## Context

This is to help reduce noise while running the test suite.

## Testing

- CI passes
- There are no noisy unnecessary noisy messages while running tests
