### PR TITLE
Add audit log feature for transactional event recording

### DIFF
--- a/app/models/concerns/strata/auditable.rb
+++ b/app/models/concerns/strata/auditable.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Strata
+  # Auditable adds an audit_lines association to any model, exposing the
+  # immutable history of actions recorded against it via {Strata::AuditLog}.
+  #
+  # Audit lines deliberately do NOT cascade-destroy with the host record:
+  # an audit trail should outlive its subject so the history of "this record
+  # was deleted" remains queryable.
+  #
+  # @example
+  #   class Case < ApplicationRecord
+  #     include Strata::Auditable
+  #   end
+  #
+  #   case_record.audit_lines.latest_first
+  module Auditable
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :audit_lines, as: :subject, class_name: "Strata::AuditLine"
+    end
+  end
+end

--- a/app/models/strata/application_form.rb
+++ b/app/models/strata/application_form.rb
@@ -23,7 +23,6 @@ module Strata
 
     include Strata::Attributes
     include Strata::Determinable
-    include Strata::Auditable
 
     define_model_callbacks :submit, only: [ :before, :after ]
 

--- a/app/models/strata/application_form.rb
+++ b/app/models/strata/application_form.rb
@@ -23,6 +23,7 @@ module Strata
 
     include Strata::Attributes
     include Strata::Determinable
+    include Strata::Auditable
 
     define_model_callbacks :submit, only: [ :before, :after ]
 

--- a/app/models/strata/audit_line.rb
+++ b/app/models/strata/audit_line.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Strata
+  # AuditLine is an immutable record of something that happened. Each line carries
+  # an action string, an optional polymorphic subject (the record the event is
+  # about), an optional polymorphic actor (who did it), and a free-form jsonb
+  # `data` payload for caller-supplied details.
+  #
+  # Lines are typically created via {Strata::AuditLog.record} (block form, wrapped
+  # in a DB transaction) or {Strata::AuditLog.write!} (single-line form). Once
+  # persisted, lines are read-only — updates and destroys raise
+  # ActiveRecord::ReadOnlyRecord.
+  #
+  # @example Querying audit history for a record
+  #   Strata::AuditLine.for_subject(case_record).latest_first
+  class AuditLine < ApplicationRecord
+    self.table_name = "strata_audit_lines"
+
+    belongs_to :subject, polymorphic: true, optional: true
+    belongs_to :actor,   polymorphic: true, optional: true
+
+    validates :action, presence: true
+
+    scope :for_subject, ->(subject) { where(subject: subject) }
+    scope :by_actor,    ->(actor)   { where(actor: actor) }
+    scope :with_action, ->(action)  { where(action: action.to_s) }
+    scope :latest_first, -> { order(created_at: :desc) }
+
+    def readonly?
+      persisted?
+    end
+  end
+end

--- a/app/models/strata/audit_line.rb
+++ b/app/models/strata/audit_line.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
 module Strata
-  # AuditLine is an immutable record of something that happened. Each line carries
-  # an action string, an optional polymorphic subject (the record the event is
-  # about), an optional polymorphic actor (who did it), and a free-form jsonb
-  # `data` payload for caller-supplied details.
+  # AuditLine is an immutable record of something that happened.
+  #
+  # Columns:
+  # - `action` (string, required) — short event name, e.g. `"case.approved"`.
+  # - `subject_type` / `subject_id` (polymorphic, optional) — the record the
+  #   event is about.
+  # - `actor_type` / `actor_id` (polymorphic, optional) — who did it.
+  # - `data` (jsonb, defaults to `{}`) — free-form caller-supplied payload.
+  # - `created_at` (datetime) — when the line was recorded. There is no
+  #   `updated_at`; lines are immutable.
   #
   # Lines are typically created via {Strata::AuditLog.record} (block form, wrapped
   # in a DB transaction) or {Strata::AuditLog.write!} (single-line form). Once

--- a/app/models/strata/audit_log.rb
+++ b/app/models/strata/audit_log.rb
@@ -39,6 +39,14 @@ module Strata
   #   persisted rows remain correct (Postgres serializes inserts), only the
   #   returned array can be incomplete in that case.
   class AuditLog
+    # The default actor passed to {.record}, applied to every appended line that
+    # doesn't pass its own `actor:` to {#add_line}.
+    attr_reader :default_actor
+
+    # The persisted lines appended during a {.record} block. Populated as
+    # {#add_line} is called inside the block.
+    attr_reader :lines
+
     # Open a wrapping DB transaction and yield an AuditLog the caller can
     # append lines to. Returns the AuditLog with {#lines} populated on success.
     # On exception, the transaction rolls back and the exception propagates.
@@ -47,7 +55,10 @@ module Strata
     #   doesn't pass its own `actor:` to {#add_line}
     # @yieldparam log [Strata::AuditLog]
     # @return [Strata::AuditLog]
+    # @raise [ArgumentError] if called without a block
     def self.record(actor: nil)
+      raise ArgumentError, "Strata::AuditLog.record requires a block" unless block_given?
+
       log = new(default_actor: actor)
       ActiveRecord::Base.transaction { yield(log) }
       log
@@ -95,7 +106,5 @@ module Strata
       @lines << line
       line
     end
-
-    attr_reader :lines
   end
 end

--- a/app/models/strata/audit_log.rb
+++ b/app/models/strata/audit_log.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module Strata
+  # AuditLog is the developer-facing API for writing audit history.
+  #
+  # The block form wraps an ActiveRecord transaction so the appended lines and
+  # the caller's domain writes commit (or roll back) together. The single-line
+  # form is a shortcut for one-off events that don't need a wrapper.
+  #
+  # @example Block form — multiple lines, atomic with caller's work
+  #   Strata::AuditLog.record(actor: current_user) do |log|
+  #     case_record.update!(status: :approved)
+  #     log.add_line(
+  #       action: "case.approved",
+  #       subject: case_record,
+  #       data: { previous_status: "pending" }
+  #     )
+  #   end
+  #
+  # @example Single-line form
+  #   Strata::AuditLog.write!(
+  #     action: "user.signed_in",
+  #     actor: current_user,
+  #     data: { ip: request.remote_ip }
+  #   )
+  #
+  # @note Nested transactions: if a host already has an outer
+  #   ActiveRecord::Base.transaction open, the block's transaction becomes a
+  #   savepoint. ActiveRecord::Rollback raised inside the block only rolls back
+  #   to that savepoint, not the outer transaction.
+  #
+  # @note after_commit callbacks on AuditLine fire only when the outermost
+  #   transaction commits. Relevant if downstream code ships audit lines to an
+  #   external sink via callbacks.
+  #
+  # @note Thread safety: each call to {.record} builds its own AuditLog
+  #   instance, so concurrent web requests never share state. The accumulator
+  #   in {#lines} is not thread-safe across threads spawned inside the block;
+  #   persisted rows remain correct (Postgres serializes inserts), only the
+  #   returned array can be incomplete in that case.
+  class AuditLog
+    # Open a wrapping DB transaction and yield an AuditLog the caller can
+    # append lines to. Returns the AuditLog with {#lines} populated on success.
+    # On exception, the transaction rolls back and the exception propagates.
+    #
+    # @param actor [Object, nil] default actor applied to every line that
+    #   doesn't pass its own `actor:` to {#add_line}
+    # @yieldparam log [Strata::AuditLog]
+    # @return [Strata::AuditLog]
+    def self.record(actor: nil)
+      log = new(default_actor: actor)
+      ActiveRecord::Base.transaction { yield(log) }
+      log
+    end
+
+    # Create a single audit line outside any wrapper transaction.
+    #
+    # @param action [String] required
+    # @param actor [Object, nil] any AR record (polymorphic)
+    # @param subject [Object, nil] any AR record (polymorphic)
+    # @param data [Hash, nil] arbitrary jsonb payload; nil is coerced to {}
+    # @return [Strata::AuditLine] the persisted line
+    # @raise [ActiveRecord::RecordInvalid] if validation fails
+    def self.write!(action:, actor: nil, subject: nil, data: {})
+      AuditLine.create!(
+        action: action,
+        actor: actor,
+        subject: subject,
+        data: data || {}
+      )
+    end
+
+    def initialize(default_actor: nil)
+      @default_actor = default_actor
+      @lines = []
+    end
+
+    # Append a line within the wrapping transaction.
+    #
+    # @param action [String] required
+    # @param subject [Object, nil] any AR record (polymorphic)
+    # @param data [Hash, nil] arbitrary jsonb payload; nil is coerced to {}
+    # @param actor [Object, nil] per-line actor override; falls back to the
+    #   default actor passed to {.record}
+    # @return [Strata::AuditLine] the persisted line
+    # @raise [ActiveRecord::RecordInvalid] if validation fails (also rolls back
+    #   the surrounding transaction)
+    def add_line(action:, subject: nil, data: {}, actor: nil)
+      line = AuditLine.create!(
+        action: action,
+        subject: subject,
+        actor: actor || @default_actor,
+        data: data || {}
+      )
+      @lines << line
+      line
+    end
+
+    attr_reader :lines
+  end
+end

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Welcome to the Strata SDK documentation. This index provides an organized overvi
 - [Multi-Page Form Flows](./multi-page-form-flows.md) - Create complex forms that span multiple pages
 - [Business process family tree](./business-process-family-tree.md) - Understanding business process hierarchies
 - [Strata Rules Engine](./strata-rules-engine.md) - Introduction to the rules engine for business logic
+- [Strata Audit Log](./strata-audit-log.md) - Record an immutable trail of actions, atomic with the surrounding domain writes
 
 ## Implementation guides
 

--- a/docs/decisions/audit-log-pii-redaction.md
+++ b/docs/decisions/audit-log-pii-redaction.md
@@ -1,0 +1,240 @@
+# Design Spec: PII redaction for `Strata::AuditLine#data`
+
+## Status
+
+Proposed (not implemented)
+
+## Date
+
+2026-05-06
+
+## Context
+
+`Strata::AuditLine#data` is a free-form `jsonb` column. The audit log API
+(`Strata::AuditLog.record` / `.write!` / `#add_line`) accepts whatever hash the
+caller passes and persists it verbatim. There is no scrubbing, no allow-list,
+and no callback hook for hosts to register a redactor.
+
+This is convenient for the common case ("record what changed") but creates a
+realistic privacy hazard: a caller can pass `data: { params: request.params }`,
+`data: { user: user.attributes }`, or any similar shorthand and accidentally
+persist passwords, session tokens, SSNs, or other PII into a permanent log
+that no one routinely audits.
+
+The current docs warn against this in prose, but a documentation rule cannot
+prevent the mistake — it only flags it after the fact, and only for callers
+who read the docs first.
+
+## Goals
+
+- Give host applications a way to declare *which* attributes on an auditable
+  subject should appear in the audit `data` payload, so the audit log captures
+  meaningful before/after diffs without leaking everything.
+- Keep the API ergonomic. Audit calls today are one-liners; they should remain
+  one-liners.
+- Make safe behavior the default for hosts that opt in. A host that sets up
+  the redaction policy should not have to remember to apply it at every call
+  site.
+- Out of scope: redacting freeform strings, regex-based scrubbing of unknown
+  payloads, encryption-at-rest of `data`. Those are separate concerns.
+
+## Non-goals
+
+- This is **not** a substitute for not putting secrets in `data`. Hosts that
+  pass arbitrary `request.params` will still leak — the goal here is to make
+  the structured-attribute path safe by default, not to police arbitrary
+  hashes.
+- This does not retroactively scrub existing audit lines. Hosts that need to
+  remediate historical PII must run their own data migration.
+
+## Design options considered
+
+### Option A — Whitelist on the subject model (proposed default)
+
+The `Strata::Auditable` concern gains a class-level DSL that declares which
+attributes are safe to capture in audit `data`:
+
+```ruby
+class Case < ApplicationRecord
+  include Strata::Auditable
+
+  audit_attributes :status, :assigned_to_id, :priority
+end
+```
+
+Two helpers ship alongside it:
+
+- `record.audit_snapshot` — returns `{ "status" => "approved", ... }`, the
+  current values of the whitelisted attributes.
+- `record.audit_diff` — returns `{ "status" => ["pending", "approved"] }`,
+  using ActiveModel::Dirty (or `previous_changes` post-save) restricted to the
+  whitelisted attributes.
+
+Callers use these in their `data:` payloads:
+
+```ruby
+log.add_line(
+  action: "case.approved",
+  subject: case_record,
+  data: { changes: case_record.audit_diff }
+)
+```
+
+Anything not listed in `audit_attributes` is *unreachable* through these
+helpers, so a future refactor can't accidentally start logging a new PII
+field.
+
+**Pros:**
+- Safe by default — any attribute not explicitly listed is never logged.
+- Self-documenting — reading the model tells you what shows up in audit
+  history.
+- Small surface area — one class macro, two helper methods.
+
+**Cons:**
+- Requires every auditable model to declare its list. New attributes that
+  *should* be audited must be added explicitly.
+- Doesn't help callers who pass arbitrary hashes (e.g. `data: { ip: ... }`)
+  rather than going through `audit_diff` / `audit_snapshot`. That's intentional
+  — callers who freeform-construct `data` are responsible for that data.
+
+### Option B — Blacklist on the subject model
+
+Inverted form: hosts list the attributes they want *excluded*.
+
+```ruby
+class User < ApplicationRecord
+  include Strata::Auditable
+
+  audit_blacklist :password_digest, :ssn, :session_token
+end
+```
+
+`audit_snapshot` returns all attributes minus the blacklist.
+
+**Pros:**
+- Easier first-time adoption — one line to mark sensitive fields.
+- Doesn't require the host to remember every attribute that *should* be
+  audited.
+
+**Cons:**
+- Unsafe by default. A new column added to the model after the blacklist was
+  written is automatically captured in audit history, even if it carries PII.
+  This is precisely the failure mode the feature is meant to prevent.
+- Drifts silently: nothing connects "we added this column" to "we should add
+  it to the blacklist."
+
+### Option C — Caller-supplied redactor block
+
+A global registration hook on the audit log:
+
+```ruby
+Strata::AuditLog.redact_data do |data|
+  data.except("password", "ssn", "token")
+end
+```
+
+The block runs once per persisted line just before `create!`.
+
+**Pros:**
+- Zero per-model boilerplate; one place to define the rule.
+- Composes with arbitrary `data` hashes (not just the structured-attribute
+  path).
+
+**Cons:**
+- Operates on hash keys without knowing semantics — easy to miss a key
+  spelled differently (`pw`, `secret`, `auth_token`).
+- Centralizes the policy in a place far from the model that owns the data.
+  When someone adds a new sensitive field on `User`, they have to remember to
+  go edit a global redactor file in a separate part of the app.
+- Doesn't help with structured diffs — to use it usefully, callers still need
+  to construct `data` themselves.
+
+### Hybrid option (recommended)
+
+Ship **A as the primary mechanism** and leave **C as a separate, opt-in
+escape hatch** for hosts that need defense-in-depth on freeform `data`. Skip
+B entirely — the unsafe-by-default failure mode disqualifies it.
+
+## API sketch
+
+```ruby
+module Strata
+  module Auditable
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :audit_lines, as: :subject, class_name: "Strata::AuditLine"
+      class_attribute :_audit_attributes, default: []
+    end
+
+    class_methods do
+      # Declare which attributes are safe to include in audit `data` payloads.
+      # Anything not listed here is unreachable via `audit_snapshot` /
+      # `audit_diff`.
+      def audit_attributes(*names)
+        self._audit_attributes = (_audit_attributes + names.map(&:to_s)).uniq
+      end
+    end
+
+    # Current values of whitelisted attributes.
+    def audit_snapshot
+      attributes.slice(*self.class._audit_attributes)
+    end
+
+    # Per-attribute changes for whitelisted attributes only.
+    # Use during/after an update.
+    def audit_diff
+      changes = saved_changes.presence || changes_to_save
+      changes.slice(*self.class._audit_attributes)
+    end
+  end
+end
+```
+
+Optional global redactor (Option C, additive):
+
+```ruby
+module Strata
+  class AuditLog
+    class << self
+      attr_accessor :data_redactor # ->(hash) { ... }
+    end
+  end
+end
+
+# In add_line / write!, before create!:
+data = data || {}
+data = self.class.data_redactor.call(data) if self.class.data_redactor
+```
+
+## Migration path
+
+1. Land `audit_attributes` DSL + helpers as additive non-breaking change. No
+   existing call sites change.
+2. Add a doc section showing the `audit_diff` / `audit_snapshot` pattern.
+3. (Future) flag direct `record.attributes` usage in the data payload as a
+   smell during code review. Not enforced programmatically.
+
+## Open questions
+
+1. Should `audit_attributes` raise when a listed attribute does not exist on
+   the model (typo guard), or should it silently ignore? Lean toward raising
+   at class definition time.
+2. Should `audit_diff` use `previous_changes` (post-save) by default, or
+   `changes_to_save` (pre-save)? Probably both: `audit_diff(:before_save)` vs
+   `audit_diff(:after_save)`, with `:after_save` as the default since most
+   audit calls happen post-update.
+3. How does this interact with strata attributes (Address, MemorableDate,
+   etc.) that span multiple columns? Probably needs a follow-up: the macro
+   should accept a `Strata::Attribute` name and expand it to the underlying
+   column set.
+4. Out-of-scope but worth filing: should there be a query-time redaction for
+   audit lines that already exist? E.g. a host could install a per-subject
+   `audit_render(line)` hook that the dummy view (and any host viewer) calls
+   before displaying `data`.
+
+## Tracking
+
+This document is the design baseline. Implementation should land as a separate
+PR with its own tests, docs update, and migration story for hosts that have
+already adopted `Strata::Auditable`.

--- a/docs/strata-audit-log.md
+++ b/docs/strata-audit-log.md
@@ -10,7 +10,7 @@ Reach for the audit log when you need a permanent record of an action that:
 - Should be coupled to the success of the underlying work — if the domain write fails, the audit entry should not appear.
 - May need to outlive the record it describes (the trail of "this case was deleted" stays queryable even after the case is gone).
 
-For lightweight diagnostic logging that doesn't need to survive a rollback, plain `Rails.logger` is still the right tool.
+For lightweight diagnostic logging that doesn't need to survive a rollback, plain `Rails.logger` is still the right tool. The audit log is also **not** the right place for telemetry-style metrics (page views, click counts, performance timings) — those belong in your application metrics pipeline, not a permanent transactional log.
 
 ## Quick start
 
@@ -71,7 +71,7 @@ class Case < ApplicationRecord
 end
 ```
 
-`Strata::ApplicationForm` already includes it, so any application form subclass gets `audit_lines` for free.
+`Strata::Auditable` is opt-in — host applications include it on the models that need an audit trail. It is intentionally **not** mixed into `Strata::ApplicationForm` so that adding the audit log feature isn't a breaking change for existing host apps.
 
 The concern adds a `has_many :audit_lines, as: :subject` association. Combine it with the scopes on `Strata::AuditLine`:
 
@@ -105,6 +105,35 @@ The generator copies `db/migrate/<timestamp>_create_strata_audit_lines.rb`. It d
 
 Pass `--skip-migration-check` to suppress the post-generate prompt that asks whether to run `db:migrate` immediately.
 
+## Authorization
+
+Audit lines are polymorphic, which means the audit table mixes records belonging to different host models in one place. Hosts must wire authorization themselves — there is no global "you can see all audit lines" rule that's safe by default.
+
+The recommended pattern is a Pundit `Strata::AuditLinePolicy::Scope` that filters audit lines by joining each subject type to that subject's existing policy scope. The dummy app under `spec/dummy/app/policies/strata/audit_line_policy.rb` ships a reference implementation hosts can copy and adapt:
+
+```ruby
+class Strata::AuditLinePolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+    def visible_subject_ids_by_type
+      {
+        "Case"            => Pundit.policy_scope(user, Case).select(:id),
+        "MyApplicationForm" => Pundit.policy_scope(user, MyApplicationForm).select(:id)
+      }
+    end
+
+    def resolve
+      filters = visible_subject_ids_by_type.map do |type, ids|
+        scope.where(subject_type: type, subject_id: ids)
+      end
+      filters << scope.where(subject_id: nil) # system events visible to all
+      filters.reduce { |combined, next_filter| combined.or(next_filter) }
+    end
+  end
+end
+```
+
+Then call `policy_scope(Strata::AuditLine)` in any controller that lists audit history.
+
 ## Schema
 
 `strata_audit_lines` (UUID primary key, immutable rows):
@@ -128,13 +157,15 @@ Indexes:
 
 ## Immutability
 
-`Strata::AuditLine#readonly?` returns `true` once a line is persisted, so updates and destroys raise `ActiveRecord::ReadOnlyRecord`:
+`Strata::AuditLine#readonly?` returns `true` once a line is persisted, so any attempt to mutate or destroy a persisted line **raises an exception** rather than silently failing:
 
 ```ruby
 line = Strata::AuditLog.write!(action: "user.signed_in", actor: current_user)
-line.update!(action: "tampered") # => ActiveRecord::ReadOnlyRecord
-line.destroy                     # => ActiveRecord::ReadOnlyRecord
+line.update!(action: "tampered") # raises ActiveRecord::ReadOnlyRecord
+line.destroy                     # raises ActiveRecord::ReadOnlyRecord
 ```
+
+Both `update!` and `destroy` raise `ActiveRecord::ReadOnlyRecord` — there is no soft-fail return value to check; expect callers to catch the exception or simply avoid mutating audit lines.
 
 This is application-level enforcement, not a database constraint. A host app that wants harder guarantees can add a `BEFORE UPDATE/DELETE` trigger.
 
@@ -170,7 +201,10 @@ Unlike `Strata::Determinable`, `Strata::Auditable` deliberately omits `dependent
 
 ### 4. Polymorphic class name drift
 
-The polymorphic columns store class name **strings** (`"Case"`, `"User"`, etc.). If you rename a host model later, existing `audit_lines` rows still reference the old name. Either avoid renaming audited models, or run a data migration to rewrite `subject_type` / `actor_type` when you do.
+The polymorphic columns store class name **strings** (`"Case"`, `"User"`, etc.) — *not* the parent class name. Two situations to watch for:
+
+- **Renames.** If you rename a host model later, existing `audit_lines` rows still reference the old name. Either avoid renaming audited models, or run a data migration to rewrite `subject_type` / `actor_type` when you do.
+- **STI / child models.** If you record audit lines against a subclass of `Strata::ApplicationForm` (e.g. `PassportApplicationForm`), the stored `subject_type` is the concrete subclass name, *not* `"Strata::ApplicationForm"`. Queries like `where(subject_type: "Strata::ApplicationForm")` will return no rows. Filter by the concrete class name (or use `for_subject(record)` which does the right thing automatically).
 
 ### 5. Thread safety
 

--- a/docs/strata-audit-log.md
+++ b/docs/strata-audit-log.md
@@ -1,0 +1,186 @@
+# Strata Audit Log
+
+The Strata Audit Log lets you record an immutable trail of what happened in your application — who did what, to which record, and any free-form context — and have those entries roll back atomically with the surrounding domain writes when something fails.
+
+## When to use it
+
+Reach for the audit log when you need a permanent record of an action that:
+
+- Affects a domain record and would benefit from "what changed and why" history (e.g. a case was approved, a form was submitted, a determination was overridden).
+- Should be coupled to the success of the underlying work — if the domain write fails, the audit entry should not appear.
+- May need to outlive the record it describes (the trail of "this case was deleted" stays queryable even after the case is gone).
+
+For lightweight diagnostic logging that doesn't need to survive a rollback, plain `Rails.logger` is still the right tool.
+
+## Quick start
+
+### Atomic, multi-line writes
+
+`Strata::AuditLog.record` opens an `ActiveRecord::Base.transaction`, yields a log object you append lines to, and commits everything together. If the block raises, every appended line is rolled back along with the caller's domain writes.
+
+```ruby
+Strata::AuditLog.record(actor: current_user) do |log|
+  case_record.update!(status: :approved)
+
+  log.add_line(
+    action: "case.approved",
+    subject: case_record,
+    data: { previous_status: "pending", reasons: ruleset_output.reasons }
+  )
+
+  notification.deliver!
+  log.add_line(action: "notification.sent", data: { channel: "email" })
+end
+```
+
+`record` returns the `Strata::AuditLog` instance with `.lines` populated, so you can inspect the persisted records:
+
+```ruby
+result = Strata::AuditLog.record(actor: current_user) { |log| log.add_line(action: "x") }
+result.lines.first # => #<Strata::AuditLine action: "x", actor_id: ..., ...>
+```
+
+### Single-line writes
+
+For a one-off event that doesn't need to be paired with other writes, use `Strata::AuditLog.write!`. It creates a single line outside any wrapper transaction:
+
+```ruby
+Strata::AuditLog.write!(
+  action: "user.signed_in",
+  actor: current_user,
+  data: { ip: request.remote_ip }
+)
+```
+
+### `add_line` / `write!` parameters
+
+| Field     | Required | Type                    | Notes                                                                              |
+| --------- | -------- | ----------------------- | ---------------------------------------------------------------------------------- |
+| `action`  | yes      | `String`                | A short event name. Convention: `"<noun>.<verb>"` (e.g. `"case.approved"`).        |
+| `subject` | no       | any AR record           | Polymorphic — the record this event is about.                                      |
+| `actor`   | no       | any AR record           | Polymorphic — who did it. Falls back to the `actor:` passed to `record`.           |
+| `data`    | no       | `Hash` (or `nil`)       | Free-form jsonb payload. `nil` is coerced to `{}`. Defaults to `{}` when omitted.  |
+
+## Querying audit history
+
+Include `Strata::Auditable` in any model that should expose its history:
+
+```ruby
+class Case < ApplicationRecord
+  include Strata::Auditable
+end
+```
+
+`Strata::ApplicationForm` already includes it, so any application form subclass gets `audit_lines` for free.
+
+The concern adds a `has_many :audit_lines, as: :subject` association. Combine it with the scopes on `Strata::AuditLine`:
+
+```ruby
+case_record.audit_lines.latest_first
+case_record.audit_lines.with_action("case.approved")
+
+Strata::AuditLine.by_actor(current_user).latest_first
+Strata::AuditLine.for_subject(case_record).with_action("case.updated")
+```
+
+Available scopes on `Strata::AuditLine`:
+
+| Scope                    | Returns                                          |
+| ------------------------ | ------------------------------------------------ |
+| `for_subject(record)`    | Lines whose subject is the given record.         |
+| `by_actor(record)`       | Lines whose actor is the given record.           |
+| `with_action(name)`      | Lines whose action matches (accepts symbols).    |
+| `latest_first`           | Ordered by `created_at` descending.              |
+
+## Installation
+
+The model, concern, and API are shipped by the engine. Only the migration needs to be installed in the host application:
+
+```bash
+bin/rails generate strata:audit_log
+bin/rails db:migrate
+```
+
+The generator copies `db/migrate/<timestamp>_create_strata_audit_lines.rb`. It does **not** scaffold a host-side `AuditLine` subclass — the schema is fixed and host-specific data goes in the jsonb `data` column.
+
+Pass `--skip-migration-check` to suppress the post-generate prompt that asks whether to run `db:migrate` immediately.
+
+## Schema
+
+`strata_audit_lines` (UUID primary key, immutable rows):
+
+| Column         | Type       | Null | Notes                                         |
+| -------------- | ---------- | ---- | --------------------------------------------- |
+| `id`           | uuid       | no   | `gen_random_uuid()`                           |
+| `action`       | string     | no   | What happened.                                |
+| `subject_id`   | uuid       | yes  | Polymorphic — paired with `subject_type`.     |
+| `subject_type` | string     | yes  |                                               |
+| `actor_id`     | uuid       | yes  | Polymorphic — paired with `actor_type`.       |
+| `actor_type`   | string     | yes  |                                               |
+| `data`         | jsonb      | no   | Defaults to `{}`. Free-form payload.          |
+| `created_at`   | datetime   | no   | No `updated_at` — lines are immutable.        |
+
+Indexes:
+
+- `(subject_type, subject_id, created_at DESC)` — serves the dominant read pattern, "most recent lines for this subject," without a sort.
+- `(actor_type, actor_id)` — for "what did this actor do."
+- `created_at` — for time-window scans.
+
+## Immutability
+
+`Strata::AuditLine#readonly?` returns `true` once a line is persisted, so updates and destroys raise `ActiveRecord::ReadOnlyRecord`:
+
+```ruby
+line = Strata::AuditLog.write!(action: "user.signed_in", actor: current_user)
+line.update!(action: "tampered") # => ActiveRecord::ReadOnlyRecord
+line.destroy                     # => ActiveRecord::ReadOnlyRecord
+```
+
+This is application-level enforcement, not a database constraint. A host app that wants harder guarantees can add a `BEFORE UPDATE/DELETE` trigger.
+
+## Gotchas
+
+### 1. Nested transactions become savepoints
+
+If you call `Strata::AuditLog.record` from inside a block that already opened an `ActiveRecord::Base.transaction`, your inner transaction becomes a **savepoint**, not a new top-level transaction.
+
+The practical consequence: `raise ActiveRecord::Rollback` inside your block only rolls back to the savepoint. The outer transaction keeps going and may still commit. If you need the whole unit of work to roll back, raise a real exception (anything other than `ActiveRecord::Rollback`) so it propagates out of the outer transaction too.
+
+```ruby
+ActiveRecord::Base.transaction do
+  case_record.update!(status: :approved)
+
+  Strata::AuditLog.record(actor: current_user) do |log|
+    log.add_line(action: "case.approved", subject: case_record)
+    raise ActiveRecord::Rollback # ← only rolls back the inner savepoint!
+  end
+
+  # We're still inside the outer transaction here, and case_record.update!
+  # is about to commit even though the audit line was discarded.
+end
+```
+
+### 2. `after_commit` fires only on the outermost commit
+
+If your application attaches `after_commit` callbacks to `Strata::AuditLine` (e.g. to ship lines to an external sink), those callbacks **fire only when the outermost transaction commits**, not when `Strata::AuditLog.record`'s inner block returns. Lines created deep in a nested transaction may take much longer than expected to reach downstream systems. Plan downstream integrations accordingly.
+
+### 3. Audit lines do **not** cascade-destroy with the subject
+
+Unlike `Strata::Determinable`, `Strata::Auditable` deliberately omits `dependent: :destroy`. This is intentional — an audit trail should outlive the record it describes so the history of "this case was deleted" remains queryable. The trade-off is that `audit_line.subject` will return `nil` once the underlying record is gone. The polymorphic `subject_type` and `subject_id` columns are preserved, so you can still query history by class+id even after deletion.
+
+### 4. Polymorphic class name drift
+
+The polymorphic columns store class name **strings** (`"Case"`, `"User"`, etc.). If you rename a host model later, existing `audit_lines` rows still reference the old name. Either avoid renaming audited models, or run a data migration to rewrite `subject_type` / `actor_type` when you do.
+
+### 5. Thread safety
+
+For normal Rails / Puma usage you don't need to think about this — every web request builds its own `Strata::AuditLog` instance, so concurrent requests never share state.
+
+The accumulator returned via `.lines` is **not** thread-safe across threads spawned **inside** the block (`Thread.new { log.add_line(...) }`, `Parallel.map(...) { |x| log.add_line(...) }`). Persisted rows remain correct in that case (Postgres serializes inserts), but the in-memory `.lines` array can be incomplete. If you fan out work inside the block, query `Strata::AuditLine` directly for what was written rather than trusting the returned accumulator.
+
+## Conventions
+
+- **Action names**: short, lowercase, dot-separated noun-then-verb strings — e.g. `"case.approved"`, `"form.submitted"`, `"notification.sent"`. This makes `with_action` filtering predictable and groups related events alphabetically.
+- **`data` payloads**: keep them small and structured. Useful contents include `{ before: ..., after: ... }` diffs, rule outputs, request metadata (IP, user agent), or external IDs. Avoid stuffing entire serialized records — the `subject` association already gives you a pointer to the live record.
+- **Actor**: pass the AR record (e.g. `current_user`), not just the ID, so the polymorphic association can hydrate it later.
+- **System events**: when there's no human actor (background jobs, cron, system boot), pass `actor: nil`. The columns are nullable.

--- a/lib/generators/strata/audit_log/USAGE
+++ b/lib/generators/strata/audit_log/USAGE
@@ -1,0 +1,47 @@
+Description:
+    Installs the strata_audit_lines migration into the host application.
+    The Strata::AuditLine model, Strata::AuditLog API, and Strata::Auditable
+    concern are shipped by the engine directly — only the migration is copied.
+
+Usage:
+    bin/rails generate strata:audit_log
+
+This will create:
+    - db/migrate/<timestamp>_create_strata_audit_lines.rb
+
+Options:
+    --skip-migration-check         Skip checking if strata_audit_lines table exists
+
+About Audit Logs:
+    AuditLines are immutable records of "what happened" in your application.
+    Each line carries an `action` string, an optional polymorphic `subject`,
+    an optional polymorphic `actor`, and a free-form jsonb `data` payload.
+
+    Use Strata::AuditLog.record for atomic multi-line writes wrapped in a DB
+    transaction (audit lines roll back with the caller's domain writes on
+    failure):
+
+        Strata::AuditLog.record(actor: current_user) do |log|
+          case_record.update!(status: :approved)
+          log.add_line(
+            action: "case.approved",
+            subject: case_record,
+            data: { previous_status: "pending" }
+          )
+        end
+
+    Use Strata::AuditLog.write! for one-off entries:
+
+        Strata::AuditLog.write!(
+          action: "user.signed_in",
+          actor: current_user,
+          data: { ip: request.remote_ip }
+        )
+
+    Include Strata::Auditable in any aggregate root to expose its history:
+
+        class Case < ApplicationRecord
+          include Strata::Auditable
+        end
+
+        case_record.audit_lines.latest_first

--- a/lib/generators/strata/audit_log/audit_log_generator.rb
+++ b/lib/generators/strata/audit_log/audit_log_generator.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+
+module Strata
+  module Generators
+    # Generator that installs the strata_audit_lines migration into the host
+    # application. The model, concern, and API class are shipped by the engine
+    # directly — only the migration needs to be copied because Rails engines
+    # don't auto-load engine migrations.
+    #
+    # @example Install the audit log migration
+    #   rails generate strata:audit_log
+    class AuditLogGenerator < Rails::Generators::Base
+      source_root File.expand_path("templates", __dir__)
+
+      class_option :"skip-migration-check", type: :boolean, default: false,
+                                            desc: "Skip checking if strata_audit_lines table exists"
+
+      def create_migration_file
+        timestamp = Time.now.utc.strftime("%Y%m%d%H%M%S")
+        template "create_strata_audit_lines.rb.tt", "db/migrate/#{timestamp}_create_strata_audit_lines.rb"
+      end
+
+      def check_strata_audit_lines_table
+        return if options[:"skip-migration-check"]
+        return if ActiveRecord::Base.connection.table_exists?(:strata_audit_lines)
+
+        say "Warning: strata_audit_lines table does not exist.", :yellow
+        if yes?("Would you like to run 'bin/rails db:migrate' now? (y/n)")
+          rails_command "db:migrate"
+        else
+          say "You may need to run 'bin/rails db:migrate' before using Strata::AuditLog.", :yellow
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/strata/audit_log/templates/create_strata_audit_lines.rb.tt
+++ b/lib/generators/strata/audit_log/templates/create_strata_audit_lines.rb.tt
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class CreateStrataAuditLines < ActiveRecord::Migration[7.2]
+  def change
+    create_table :strata_audit_lines, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      # Required: what happened
+      t.string :action, null: false
+
+      # Optional polymorphic subject (the record this event is about)
+      t.uuid   :subject_id
+      t.string :subject_type
+
+      # Optional polymorphic actor (who did it)
+      t.uuid   :actor_id
+      t.string :actor_type
+
+      # Free-form jsonb payload for caller-supplied details
+      t.jsonb :data, null: false, default: {}
+
+      # Audit lines are immutable: created_at only, no updated_at
+      t.datetime :created_at, null: false
+    end
+
+    # Composite index ordered by created_at DESC serves the dominant read
+    # pattern: "most recent audit lines for this subject"
+    add_index :strata_audit_lines, [ :subject_type, :subject_id, :created_at ],
+              order: { created_at: :desc },
+              name: "index_strata_audit_lines_on_subject_and_created_at"
+
+    add_index :strata_audit_lines, [ :actor_type, :actor_id ],
+              name: "index_strata_audit_lines_on_polymorphic_actor"
+
+    add_index :strata_audit_lines, :created_at
+  end
+end

--- a/spec/dummy/app/controllers/audit_logs_controller.rb
+++ b/spec/dummy/app/controllers/audit_logs_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AuditLogsController < StaffController
+  def index
+    @audit_lines = Strata::AuditLine.latest_first.limit(100)
+  end
+end

--- a/spec/dummy/app/controllers/audit_logs_controller.rb
+++ b/spec/dummy/app/controllers/audit_logs_controller.rb
@@ -1,7 +1,18 @@
 # frozen_string_literal: true
 
 class AuditLogsController < StaffController
+  include Pundit::Authorization
+
   def index
-    @audit_lines = Strata::AuditLine.latest_first.limit(100)
+    @audit_lines = policy_scope(Strata::AuditLine).latest_first.limit(100)
+  end
+
+  protected
+
+  # The dummy app has no Devise / authentication wiring; pick a user so the
+  # Pundit scope has something to filter against. Production hosts replace
+  # this with their real `current_user` implementation.
+  def current_user
+    User.first || User.create!(first_name: "Demo", last_name: "Staff")
   end
 end

--- a/spec/dummy/app/controllers/staff_controller.rb
+++ b/spec/dummy/app/controllers/staff_controller.rb
@@ -12,6 +12,9 @@ class StaffController < Strata::StaffController
   end
 
   def header_links
-    [ { name: "Search", path: search_path } ] + super
+    [
+      { name: "Search", path: search_path },
+      { name: "Audit logs", path: audit_logs_path }
+    ] + super
   end
 end

--- a/spec/dummy/app/models/test_application_form.rb
+++ b/spec/dummy/app/models/test_application_form.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TestApplicationForm < Strata::ApplicationForm
+  include Strata::Auditable
+
   attribute :test_string, :string
 
   strata_attribute :applicant_name, :name

--- a/spec/dummy/app/policies/strata/audit_line_policy.rb
+++ b/spec/dummy/app/policies/strata/audit_line_policy.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Strata
+  # Reference Pundit policy for Strata::AuditLine in the dummy app.
+  #
+  # Audit lines are polymorphic: each line points at some `subject_type` /
+  # `subject_id`. A staff user should only see audit lines whose subject they
+  # already have access to. Without this policy, the controller would expose
+  # the entire audit table — including history for records the user has no
+  # business reading.
+  #
+  # This policy filters Strata::AuditLine by joining each known subject type to
+  # its host-side policy scope. System events (rows with `subject_id = nil`)
+  # are visible to any logged-in user, since they describe global activity
+  # rather than a specific record.
+  #
+  # Production hosts should adapt this policy to enumerate the auditable
+  # subject types in their own application.
+  class AuditLinePolicy < ::ApplicationPolicy
+    def index?
+      user.present?
+    end
+
+    class Scope < ::ApplicationPolicy::Scope
+      # Map of subject_type → ActiveRecord scope of ids the user is allowed to
+      # see. Hosts extend this when they add new auditable models.
+      def visible_subject_ids_by_type
+        {
+          "TestApplicationForm" => ::TestApplicationForm.where(user_id: user.id).select(:id)
+        }
+      end
+
+      def resolve
+        filters = visible_subject_ids_by_type.map do |type, ids|
+          scope.where(subject_type: type, subject_id: ids)
+        end
+
+        # System events have no subject; they are visible to any logged-in user.
+        filters << scope.where(subject_id: nil)
+
+        filters.reduce { |combined, next_filter| combined.or(next_filter) }
+      end
+    end
+  end
+end

--- a/spec/dummy/app/views/audit_logs/index.html.erb
+++ b/spec/dummy/app/views/audit_logs/index.html.erb
@@ -1,46 +1,42 @@
 <h1>Audit logs</h1>
 
 <% if @audit_lines.any? %>
-  <table>
-    <thead>
-      <tr>
-        <th>Recorded at</th>
-        <th>Action</th>
-        <th>Subject</th>
-        <th>Actor</th>
-        <th>Data</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @audit_lines.each do |line| %>
-        <tr>
-          <td><%= line.created_at.iso8601 %></td>
-          <td><%= line.action %></td>
-          <td>
-            <% if line.subject_type.present? %>
-              <%= line.subject_type %> <%= line.subject_id %>
-            <% else %>
-              &mdash;
-            <% end %>
-          </td>
-          <td>
-            <% if line.actor_type.present? %>
-              <%= line.actor_type %> <%= line.actor_id %>
-            <% else %>
-              &mdash;
-            <% end %>
-          </td>
-          <td>
-            <% if line.data.present? %>
-              <pre><%= JSON.pretty_generate(line.data) %></pre>
-            <% else %>
-              &mdash;
-            <% end %>
-          </td>
-        </tr>
+  <%= render Strata::US::TableComponent.new(striped: true) do |table| %>
+    <% table.with_caption { "Most recent audit lines" } %>
+    <% table.with_header { "Recorded at" } %>
+    <% table.with_header { "Action" } %>
+    <% table.with_header { "Subject" } %>
+    <% table.with_header { "Actor" } %>
+    <% table.with_header { "Data" } %>
+
+    <% @audit_lines.each do |line| %>
+      <% table.with_row do |row| %>
+        <% row.with_cell { line.created_at.iso8601 } %>
+        <% row.with_cell { line.action } %>
+        <% row.with_cell do %>
+          <% if line.subject_type.present? %>
+            <%= line.subject_type %> <%= line.subject_id %>
+          <% else %>
+            &mdash;
+          <% end %>
+        <% end %>
+        <% row.with_cell do %>
+          <% if line.actor_type.present? %>
+            <%= line.actor_type %> <%= line.actor_id %>
+          <% else %>
+            &mdash;
+          <% end %>
+        <% end %>
+        <% row.with_cell do %>
+          <% if line.data.present? %>
+            <pre><%= JSON.pretty_generate(line.data) %></pre>
+          <% else %>
+            &mdash;
+          <% end %>
+        <% end %>
       <% end %>
-    </tbody>
-  </table>
+    <% end %>
+  <% end %>
 <% else %>
   <p>No audit logs recorded yet.</p>
 <% end %>

--- a/spec/dummy/app/views/audit_logs/index.html.erb
+++ b/spec/dummy/app/views/audit_logs/index.html.erb
@@ -1,0 +1,46 @@
+<h1>Audit logs</h1>
+
+<% if @audit_lines.any? %>
+  <table>
+    <thead>
+      <tr>
+        <th>Recorded at</th>
+        <th>Action</th>
+        <th>Subject</th>
+        <th>Actor</th>
+        <th>Data</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @audit_lines.each do |line| %>
+        <tr>
+          <td><%= line.created_at.iso8601 %></td>
+          <td><%= line.action %></td>
+          <td>
+            <% if line.subject_type.present? %>
+              <%= line.subject_type %> <%= line.subject_id %>
+            <% else %>
+              &mdash;
+            <% end %>
+          </td>
+          <td>
+            <% if line.actor_type.present? %>
+              <%= line.actor_type %> <%= line.actor_id %>
+            <% else %>
+              &mdash;
+            <% end %>
+          </td>
+          <td>
+            <% if line.data.present? %>
+              <pre><%= JSON.pretty_generate(line.data) %></pre>
+            <% else %>
+              &mdash;
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p>No audit logs recorded yet.</p>
+<% end %>

--- a/spec/dummy/app/views/home/index.html.erb
+++ b/spec/dummy/app/views/home/index.html.erb
@@ -22,6 +22,7 @@
           <li><%= link_to "Staff Dashboard", staff_path, class: "usa-link" %></li>
           <li><%= link_to "Task Queue", tasks_path, class: "usa-link" %></li>
           <li><%= link_to "Passport Cases", passport_cases_path, class: "usa-link" %></li>
+          <li><%= link_to "Audit Logs", audit_logs_path, class: "usa-link" %></li>
         </ul>
       </div>
     </div>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -42,6 +42,8 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :audit_logs, only: [ :index ]
+
     get "search", to: "staff#search"
   end
 

--- a/spec/dummy/db/migrate/20260504221320_create_strata_audit_lines.rb
+++ b/spec/dummy/db/migrate/20260504221320_create_strata_audit_lines.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class CreateStrataAuditLines < ActiveRecord::Migration[7.2]
+  def change
+    create_table :strata_audit_lines, id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      # Required: what happened
+      t.string :action, null: false
+
+      # Optional polymorphic subject (the record this event is about)
+      t.uuid   :subject_id
+      t.string :subject_type
+
+      # Optional polymorphic actor (who did it)
+      t.uuid   :actor_id
+      t.string :actor_type
+
+      # Free-form jsonb payload for caller-supplied details
+      t.jsonb :data, null: false, default: {}
+
+      # Audit lines are immutable: created_at only, no updated_at
+      t.datetime :created_at, null: false
+    end
+
+    # Composite index ordered by created_at DESC serves the dominant read
+    # pattern: "most recent audit lines for this subject"
+    add_index :strata_audit_lines, [ :subject_type, :subject_id, :created_at ],
+              order: { created_at: :desc },
+              name: "index_strata_audit_lines_on_subject_and_created_at"
+
+    add_index :strata_audit_lines, [ :actor_type, :actor_id ],
+              name: "index_strata_audit_lines_on_polymorphic_actor"
+
+    add_index :strata_audit_lines, :created_at
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_31_144038) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_04_221320) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -56,6 +56,20 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_31_144038) do
     t.string "leave_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "reviewed", default: false
+  end
+
+  create_table "strata_audit_lines", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "action", null: false
+    t.uuid "subject_id"
+    t.string "subject_type"
+    t.uuid "actor_id"
+    t.string "actor_type"
+    t.jsonb "data", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.index ["actor_type", "actor_id"], name: "index_strata_audit_lines_on_polymorphic_actor"
+    t.index ["created_at"], name: "index_strata_audit_lines_on_created_at"
+    t.index ["subject_type", "subject_id", "created_at"], name: "index_strata_audit_lines_on_subject_and_created_at", order: { created_at: :desc }
   end
 
   create_table "strata_determinations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/dummy/spec/policies/strata/audit_line_policy_spec.rb
+++ b/spec/dummy/spec/policies/strata/audit_line_policy_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Strata::AuditLinePolicy do
+  let(:user)       { create(:user) }
+  let(:other_user) { create(:user) }
+
+  describe 'Scope' do
+    subject(:resolved) { described_class::Scope.new(user, Strata::AuditLine.all).resolve }
+
+    let!(:own_form)   { create(:test_application_form, user_id: user.id) }
+    let!(:other_form) { create(:test_application_form, user_id: other_user.id) }
+
+    let!(:visible_line) do
+      create(:strata_audit_line, subject: own_form, action: 'form.created')
+    end
+
+    let!(:hidden_line) do
+      create(:strata_audit_line, subject: other_form, action: 'form.created')
+    end
+
+    let!(:system_line) do
+      create(:strata_audit_line, subject: nil, action: 'system.boot')
+    end
+
+    it 'includes audit lines whose subject the user owns' do
+      expect(resolved).to include(visible_line)
+    end
+
+    it 'excludes audit lines whose subject the user does not own' do
+      expect(resolved).not_to include(hidden_line)
+    end
+
+    it 'includes system events (lines with no subject)' do
+      expect(resolved).to include(system_line)
+    end
+
+    it 'raises when initialized without a user' do
+      expect {
+        described_class::Scope.new(nil, Strata::AuditLine.all)
+      }.to raise_error(Pundit::NotAuthorizedError)
+    end
+
+    context 'with an audit line for an unknown subject type' do
+      let!(:unknown_subject_line) do
+        Strata::AuditLine.create!(
+          action: 'mystery.event',
+          subject_type: 'SomeUnauditedClass',
+          subject_id: SecureRandom.uuid
+        )
+      end
+
+      it 'excludes audit lines for subject types the policy does not know about' do
+        expect(resolved).not_to include(unknown_subject_line)
+      end
+    end
+  end
+end

--- a/spec/dummy/spec/requests/audit_logs_spec.rb
+++ b/spec/dummy/spec/requests/audit_logs_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Audit logs', type: :request do
+  let(:user)       { User.create!(first_name: 'Test',  last_name: 'User') }
+  let(:other_user) { User.create!(first_name: 'Other', last_name: 'User') }
+
+  before do
+    # Mock current_user for the dummy app since it doesn't have Devise
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(AuditLogsController).to receive(:current_user).and_return(user)
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  describe 'GET /audit_logs' do
+    it 'renders successfully' do
+      get '/staff/audit_logs'
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'shows the empty-state message when no audit lines exist' do
+      get '/staff/audit_logs'
+      expect(response.body).to include('No audit logs recorded yet.')
+    end
+
+    context 'when audit lines exist' do
+      before do
+        own_form   = create(:test_application_form, user_id: user.id)
+        other_form = create(:test_application_form, user_id: other_user.id)
+
+        create(:strata_audit_line, subject: own_form,   action: 'form.created.visible')
+        create(:strata_audit_line, subject: other_form, action: 'form.created.hidden')
+        create(:strata_audit_line, subject: nil,        action: 'system.event.visible')
+      end
+
+      it 'shows audit lines for subjects the current user owns' do
+        get '/staff/audit_logs'
+        expect(response.body).to include('form.created.visible')
+      end
+
+      it 'hides audit lines for subjects the current user does not own' do
+        get '/staff/audit_logs'
+        expect(response.body).not_to include('form.created.hidden')
+      end
+
+      it 'shows system events (lines with no subject)' do
+        get '/staff/audit_logs'
+        expect(response.body).to include('system.event.visible')
+      end
+    end
+  end
+end

--- a/spec/factories/strata/strata_audit_line_factory.rb
+++ b/spec/factories/strata/strata_audit_line_factory.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :strata_audit_line, class: 'Strata::AuditLine' do
+    action { 'test.event' }
+    subject { nil }
+    actor { nil }
+    data { {} }
+  end
+end

--- a/spec/lib/generators/strata/generators/audit_log_generator_spec.rb
+++ b/spec/lib/generators/strata/generators/audit_log_generator_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'generators/strata/audit_log/audit_log_generator'
+require 'fileutils'
+require 'tmpdir'
+
+RSpec.describe Strata::Generators::AuditLogGenerator, type: :generator do
+  let(:destination_root) { Dir.mktmpdir }
+  let(:options)          { {} }
+  let(:generator) do
+    described_class.new([], options.merge(quiet: true), destination_root: destination_root)
+  end
+
+  before do
+    FileUtils.mkdir_p("#{destination_root}/db/migrate")
+  end
+
+  after do
+    FileUtils.rm_rf(destination_root)
+  end
+
+  describe 'file creation' do
+    before do
+      allow(ActiveRecord::Base.connection).to receive(:table_exists?)
+        .with(:strata_audit_lines).and_return(true)
+      generator.invoke_all
+    end
+
+    it 'creates a migration file' do
+      migration_file = Dir.glob("#{destination_root}/db/migrate/*_create_strata_audit_lines.rb").first
+      expect(migration_file).to be_present
+    end
+
+    it 'does NOT create a host model file (engine ships the model directly)' do
+      expect(File.exist?("#{destination_root}/app/models/audit_line.rb")).to be false
+    end
+
+    it 'does NOT create a host concern file (engine ships the concern directly)' do
+      expect(File.exist?("#{destination_root}/app/models/concerns/auditable.rb")).to be false
+    end
+
+    it 'does NOT create host spec files' do
+      expect(File.exist?("#{destination_root}/spec/models/audit_line_spec.rb")).to be false
+      expect(File.exist?("#{destination_root}/spec/models/concerns/auditable_spec.rb")).to be false
+    end
+  end
+
+  describe 'migration content' do
+    let(:migration_content) do
+      generator.invoke_all
+      migration_file = Dir.glob("#{destination_root}/db/migrate/*_create_strata_audit_lines.rb").first
+      File.read(migration_file)
+    end
+
+    before do
+      allow(ActiveRecord::Base.connection).to receive(:table_exists?)
+        .with(:strata_audit_lines).and_return(true)
+    end
+
+    it 'creates the strata_audit_lines table with a UUID primary key' do
+      expect(migration_content).to include('create_table :strata_audit_lines, id: :uuid')
+    end
+
+    it 'declares a NOT NULL action column' do
+      expect(migration_content).to match(/t\.string\s+:action,\s+null:\s+false/)
+    end
+
+    it 'declares polymorphic subject columns (both nullable)' do
+      expect(migration_content).to include(':subject_id')
+      expect(migration_content).to include(':subject_type')
+    end
+
+    it 'declares polymorphic actor columns (both nullable)' do
+      expect(migration_content).to include(':actor_id')
+      expect(migration_content).to include(':actor_type')
+    end
+
+    it 'declares a NOT NULL jsonb data column with default {}' do
+      expect(migration_content).to match(/t\.jsonb\s+:data,\s+null:\s+false,\s+default:\s+\{\}/)
+    end
+
+    it 'declares created_at without updated_at (audit lines are immutable)' do
+      expect(migration_content).to include(':created_at')
+      expect(migration_content).not_to include(':updated_at')
+      expect(migration_content).not_to include('t.timestamps')
+    end
+
+    it 'declares the composite subject + created_at index' do
+      expect(migration_content).to include('index_strata_audit_lines_on_subject_and_created_at')
+    end
+
+    it 'declares the composite actor index' do
+      expect(migration_content).to include('index_strata_audit_lines_on_polymorphic_actor')
+    end
+  end
+
+  describe 'table existence check' do
+    it 'warns when the table does not exist and the user declines migration' do
+      allow(ActiveRecord::Base.connection).to receive(:table_exists?)
+        .with(:strata_audit_lines).and_return(false)
+      allow(generator).to receive(:yes?).and_return(false)
+      allow(generator).to receive(:say)
+
+      generator.invoke_all
+
+      expect(generator).to have_received(:say).with(/strata_audit_lines table does not exist/, :yellow)
+    end
+
+    it 'skips the table check when --skip-migration-check is set' do
+      allow(generator).to receive(:say)
+      allow(ActiveRecord::Base.connection).to receive(:table_exists?)
+
+      described_class.new([], { 'skip-migration-check': true, quiet: true },
+                         destination_root: destination_root).invoke_all
+
+      expect(ActiveRecord::Base.connection).not_to have_received(:table_exists?)
+        .with(:strata_audit_lines)
+    end
+  end
+end

--- a/spec/models/concerns/strata/auditable_spec.rb
+++ b/spec/models/concerns/strata/auditable_spec.rb
@@ -2,9 +2,9 @@
 
 require 'rails_helper'
 
-# This spec assumes Strata::Auditable is included in TestApplicationForm
-# (analogous to how Strata::Determinable is included in ApplicationForm).
-# If Auditable is included via a different host model, adjust the factory accordingly.
+# Strata::Auditable is opt-in. Host apps include it on the models that need
+# an audit trail. TestApplicationForm includes it so these specs can exercise
+# the concern without inventing another host model.
 RSpec.describe Strata::Auditable do
   let(:test_form) { create(:test_application_form) }
 
@@ -31,6 +31,12 @@ RSpec.describe Strata::Auditable do
       create(:strata_audit_line, subject: test_form, action: 'form.created')
 
       expect { test_form.destroy }.not_to change(Strata::AuditLine, :count)
+    end
+  end
+
+  describe 'opt-in posture' do
+    it 'is not included in Strata::ApplicationForm by default' do
+      expect(Strata::ApplicationForm.include?(described_class)).to be(false)
     end
   end
 end

--- a/spec/models/concerns/strata/auditable_spec.rb
+++ b/spec/models/concerns/strata/auditable_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# This spec assumes Strata::Auditable is included in TestApplicationForm
+# (analogous to how Strata::Determinable is included in ApplicationForm).
+# If Auditable is included via a different host model, adjust the factory accordingly.
+RSpec.describe Strata::Auditable do
+  let(:test_form) { create(:test_application_form) }
+
+  describe 'included behavior' do
+    it 'adds an audit_lines association to the including model' do
+      expect(test_form).to respond_to(:audit_lines)
+    end
+
+    it 'returns audit_lines whose subject is the host record' do
+      line = create(:strata_audit_line, subject: test_form, action: 'form.created')
+      unrelated_form = create(:test_application_form)
+      create(:strata_audit_line, subject: unrelated_form, action: 'form.created')
+
+      expect(test_form.audit_lines).to contain_exactly(line)
+    end
+
+    it 'returns an empty collection when no audit lines exist for the host' do
+      expect(test_form.audit_lines).to be_empty
+    end
+
+    it 'does not auto-destroy audit lines when the host is destroyed' do
+      # Audit lines are immutable history — they should outlive their subject
+      # so that the trail of "what happened to this record" survives deletion.
+      create(:strata_audit_line, subject: test_form, action: 'form.created')
+
+      expect { test_form.destroy }.not_to change(Strata::AuditLine, :count)
+    end
+  end
+end

--- a/spec/models/strata/audit_line_spec.rb
+++ b/spec/models/strata/audit_line_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Strata::AuditLine do
+  describe 'associations' do
+    it { is_expected.to belong_to(:subject).optional }
+    it { is_expected.to belong_to(:actor).optional }
+  end
+
+  describe 'validations' do
+    subject { build(:strata_audit_line) }
+
+    it { is_expected.to validate_presence_of(:action) }
+  end
+
+  describe 'polymorphic subject' do
+    let(:test_form) { create(:test_application_form) }
+
+    it 'stores and retrieves polymorphic subject' do
+      line = create(:strata_audit_line, subject: test_form)
+      expect(line.subject).to eq(test_form)
+      expect(line.subject_type).to eq('TestApplicationForm')
+      expect(line.subject_id).to eq(test_form.id)
+    end
+
+    it 'allows nil subject' do
+      line = build(:strata_audit_line, subject: nil)
+      expect(line).to be_valid
+      expect { line.save! }.not_to raise_error
+    end
+  end
+
+  describe 'polymorphic actor' do
+    let(:user) { create(:user) }
+
+    it 'stores and retrieves polymorphic actor' do
+      line = create(:strata_audit_line, actor: user)
+      expect(line.actor).to eq(user)
+      expect(line.actor_type).to eq('User')
+      expect(line.actor_id).to eq(user.id)
+    end
+
+    it 'allows nil actor' do
+      line = build(:strata_audit_line, actor: nil)
+      expect(line).to be_valid
+      expect { line.save! }.not_to raise_error
+    end
+  end
+
+  describe 'data column' do
+    it 'persists arbitrary jsonb payload and round-trips it' do
+      payload = { 'changed_fields' => %w[status assignee_id], 'reason' => 'manual review' }
+      line = create(:strata_audit_line, data: payload)
+      expect(line.reload.data).to eq(payload)
+    end
+
+    it 'defaults data to {} when omitted' do
+      line = described_class.create!(action: 'system.boot')
+      expect(line.reload.data).to eq({})
+    end
+  end
+
+  describe 'created_at' do
+    it 'is set automatically on create' do
+      line = create(:strata_audit_line)
+      expect(line.created_at).to be_present
+    end
+
+    it 'has no updated_at attribute' do
+      expect(described_class.column_names).not_to include('updated_at')
+    end
+  end
+
+  describe 'immutability' do
+    let(:line) { create(:strata_audit_line) }
+
+    it 'is readonly once persisted' do
+      expect(line.readonly?).to be true
+    end
+
+    it 'is not readonly when newly built' do
+      expect(build(:strata_audit_line).readonly?).to be false
+    end
+
+    it 'raises when attempting to update an attribute' do
+      expect { line.update!(action: 'tampered') }.to raise_error(ActiveRecord::ReadOnlyRecord)
+    end
+
+    it 'raises when attempting to destroy' do
+      expect { line.destroy }.to raise_error(ActiveRecord::ReadOnlyRecord)
+    end
+  end
+
+  describe 'scopes' do
+    let(:test_form_alpha) { create(:test_application_form) }
+    let(:test_form_bravo) { create(:test_application_form) }
+    let(:user_alpha)      { create(:user) }
+    let(:user_bravo)      { create(:user) }
+
+    let!(:line_alpha_created) do
+      create(:strata_audit_line, subject: test_form_alpha, actor: user_alpha,
+                                  action: 'form.created', created_at: 3.days.ago)
+    end
+    let!(:line_alpha_updated) do
+      create(:strata_audit_line, subject: test_form_alpha, actor: user_bravo,
+                                  action: 'form.updated', created_at: 1.day.ago)
+    end
+    let!(:line_bravo_created) do
+      create(:strata_audit_line, subject: test_form_bravo, actor: user_alpha,
+                                  action: 'form.created', created_at: 2.days.ago)
+    end
+
+    describe '.for_subject' do
+      it 'returns only lines for the given subject' do
+        expect(described_class.for_subject(test_form_alpha))
+          .to contain_exactly(line_alpha_created, line_alpha_updated)
+      end
+
+      it 'returns empty when subject has no lines' do
+        new_form = create(:test_application_form)
+        expect(described_class.for_subject(new_form)).to be_empty
+      end
+    end
+
+    describe '.by_actor' do
+      it 'returns only lines for the given actor' do
+        expect(described_class.by_actor(user_alpha))
+          .to contain_exactly(line_alpha_created, line_bravo_created)
+      end
+    end
+
+    describe '.with_action' do
+      it 'filters by action string' do
+        expect(described_class.with_action('form.created'))
+          .to contain_exactly(line_alpha_created, line_bravo_created)
+      end
+
+      it 'accepts symbol' do
+        expect(described_class.with_action(:'form.updated'))
+          .to contain_exactly(line_alpha_updated)
+      end
+    end
+
+    describe '.latest_first' do
+      it 'orders by created_at descending' do
+        results = described_class.latest_first
+        expect(results.first).to eq(line_alpha_updated)
+        expect(results.last).to eq(line_alpha_created)
+      end
+    end
+
+    describe 'chaining' do
+      it 'composes for_subject with with_action' do
+        expect(described_class.for_subject(test_form_alpha).with_action('form.created'))
+          .to contain_exactly(line_alpha_created)
+      end
+    end
+  end
+end

--- a/spec/models/strata/audit_log_spec.rb
+++ b/spec/models/strata/audit_log_spec.rb
@@ -203,6 +203,23 @@ RSpec.describe Strata::AuditLog do
         }.not_to change(Strata::AuditLine, :count)
       end
     end
+
+    context 'when called without a block' do
+      it 'raises ArgumentError with a helpful message' do
+        expect { described_class.record(actor: user) }
+          .to raise_error(ArgumentError, /requires a block/)
+      end
+
+      it 'does not persist any audit lines' do
+        expect {
+          begin
+            described_class.record(actor: user)
+          rescue ArgumentError
+            # expected
+          end
+        }.not_to change(Strata::AuditLine, :count)
+      end
+    end
   end
 
   describe '.write!' do

--- a/spec/models/strata/audit_log_spec.rb
+++ b/spec/models/strata/audit_log_spec.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Strata::AuditLog do
+  let(:user)        { create(:user) }
+  let(:other_user)  { create(:user) }
+  let(:test_form)   { create(:test_application_form) }
+
+  describe '.record' do
+    it 'returns a Strata::AuditLog instance' do
+      result = described_class.record(actor: user) { |log| log.add_line(action: 'noop') }
+      expect(result).to be_a(described_class)
+    end
+
+    it 'yields a log object the caller can append lines to' do
+      yielded = nil
+      described_class.record(actor: user) { |log| yielded = log }
+      expect(yielded).to be_a(described_class)
+    end
+
+    it 'persists every appended line' do
+      expect {
+        described_class.record(actor: user) do |log|
+          log.add_line(action: 'a', subject: test_form, data: { i: 1 })
+          log.add_line(action: 'b', subject: test_form, data: { i: 2 })
+        end
+      }.to change(Strata::AuditLine, :count).by(2)
+    end
+
+    it 'exposes the persisted lines via .lines after the block returns' do
+      result = described_class.record(actor: user) do |log|
+        log.add_line(action: 'a', subject: test_form)
+        log.add_line(action: 'b', subject: test_form)
+      end
+
+      expect(result.lines.length).to eq(2)
+      expect(result.lines).to all(be_persisted)
+      expect(result.lines.map(&:action)).to eq(%w[a b])
+    end
+
+    it 'wraps appended lines in a database transaction' do
+      allow(ActiveRecord::Base).to receive(:transaction).and_call_original
+
+      described_class.record(actor: user) { |log| log.add_line(action: 'wrapped') }
+
+      expect(ActiveRecord::Base).to have_received(:transaction)
+    end
+
+    context 'when the block raises an exception' do
+      it 'rolls back all appended lines' do
+        expect {
+          begin
+            described_class.record(actor: user) do |log|
+              log.add_line(action: 'before-raise', subject: test_form)
+              raise StandardError, 'boom'
+            end
+          rescue StandardError
+            # expected
+          end
+        }.not_to change(Strata::AuditLine, :count)
+      end
+
+      it 'propagates the exception' do
+        expect {
+          described_class.record(actor: user) do |log|
+            log.add_line(action: 'x')
+            raise StandardError, 'boom'
+          end
+        }.to raise_error(StandardError, 'boom')
+      end
+
+      it 'rolls back caller writes inside the same transaction' do
+        existing_form = create(:test_application_form)
+
+        expect {
+          begin
+            described_class.record(actor: user) do |log|
+              existing_form.update!(updated_at: 1.year.from_now)
+              log.add_line(action: 'updated', subject: existing_form)
+              raise StandardError, 'boom'
+            end
+          rescue StandardError
+            # expected
+          end
+        }.not_to(change { existing_form.reload.updated_at })
+      end
+    end
+
+    context 'when the block raises ActiveRecord::Rollback' do
+      it 'silently rolls back appended lines' do
+        expect {
+          described_class.record(actor: user) do |log|
+            log.add_line(action: 'discarded')
+            raise ActiveRecord::Rollback
+          end
+        }.not_to change(Strata::AuditLine, :count)
+      end
+
+      it 'does not propagate the exception' do
+        expect {
+          described_class.record(actor: user) do |log|
+            log.add_line(action: 'discarded')
+            raise ActiveRecord::Rollback
+          end
+        }.not_to raise_error
+      end
+    end
+
+    context 'with actor handling' do
+      it 'uses the block-level default actor for appended lines' do
+        result = described_class.record(actor: user) do |log|
+          log.add_line(action: 'a')
+          log.add_line(action: 'b')
+        end
+
+        expect(result.lines.map(&:actor)).to all(eq(user))
+      end
+
+      it 'allows per-line override of actor' do
+        result = described_class.record(actor: user) do |log|
+          log.add_line(action: 'a')
+          log.add_line(action: 'b', actor: other_user)
+        end
+
+        expect(result.lines[0].actor).to eq(user)
+        expect(result.lines[1].actor).to eq(other_user)
+      end
+
+      it 'allows nil actor when no default is set and none passed' do
+        result = described_class.record do |log|
+          log.add_line(action: 'system.event')
+        end
+
+        expect(result.lines.first.actor).to be_nil
+      end
+    end
+
+    context 'with data handling' do
+      it 'persists the supplied jsonb payload' do
+        result = described_class.record(actor: user) do |log|
+          log.add_line(action: 'a', data: { 'foo' => 'bar' })
+        end
+
+        expect(result.lines.first.reload.data).to eq({ 'foo' => 'bar' })
+      end
+
+      it 'coerces nil data to {}' do
+        result = described_class.record(actor: user) do |log|
+          log.add_line(action: 'a', data: nil)
+        end
+
+        expect(result.lines.first.reload.data).to eq({})
+      end
+
+      it 'defaults data to {} when omitted' do
+        result = described_class.record(actor: user) do |log|
+          log.add_line(action: 'a')
+        end
+
+        expect(result.lines.first.reload.data).to eq({})
+      end
+    end
+
+    context 'with subject handling' do
+      it 'allows nil subject (system events)' do
+        result = described_class.record(actor: user) do |log|
+          log.add_line(action: 'system.boot')
+        end
+
+        expect(result.lines.first.subject).to be_nil
+      end
+
+      it 'persists polymorphic subject correctly' do
+        result = described_class.record(actor: user) do |log|
+          log.add_line(action: 'form.viewed', subject: test_form)
+        end
+
+        line = result.lines.first
+        expect(line.subject).to eq(test_form)
+        expect(line.subject_type).to eq('TestApplicationForm')
+        expect(line.subject_id).to eq(test_form.id)
+      end
+    end
+
+    context 'when validation fails' do
+      it 'raises when action is missing' do
+        expect {
+          described_class.record(actor: user) { |log| log.add_line(action: nil) }
+        }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+
+      it 'rolls back the entire transaction on a validation failure mid-block' do
+        expect {
+          begin
+            described_class.record(actor: user) do |log|
+              log.add_line(action: 'first')
+              log.add_line(action: nil) # validation failure -> raises
+            end
+          rescue ActiveRecord::RecordInvalid
+            # expected
+          end
+        }.not_to change(Strata::AuditLine, :count)
+      end
+    end
+  end
+
+  describe '.write!' do
+    it 'creates a single Strata::AuditLine row' do
+      expect {
+        described_class.write!(action: 'user.signed_in', actor: user)
+      }.to change(Strata::AuditLine, :count).by(1)
+    end
+
+    it 'returns the persisted AuditLine' do
+      line = described_class.write!(action: 'user.signed_in', actor: user)
+      expect(line).to be_a(Strata::AuditLine)
+      expect(line).to be_persisted
+    end
+
+    it 'persists action, actor, subject, and data' do
+      line = described_class.write!(
+        action: 'form.viewed',
+        actor: user,
+        subject: test_form,
+        data: { 'ip' => '127.0.0.1' }
+      )
+
+      expect(line.action).to eq('form.viewed')
+      expect(line.actor).to eq(user)
+      expect(line.subject).to eq(test_form)
+      expect(line.data).to eq({ 'ip' => '127.0.0.1' })
+    end
+
+    it 'allows nil actor and nil subject' do
+      line = described_class.write!(action: 'system.startup')
+      expect(line.actor).to be_nil
+      expect(line.subject).to be_nil
+    end
+
+    it 'coerces nil data to {}' do
+      line = described_class.write!(action: 'a', data: nil)
+      expect(line.data).to eq({})
+    end
+
+    it 'raises ActiveRecord::RecordInvalid when action is missing' do
+      expect { described_class.write!(action: nil) }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add audit log feature with transactional event recording, documentation, and comprehensive testing.

## Changes

- Add audit log feature for transactional event recording
- Document the audit log feature and PII redaction mechanism
- Add audit log view to dummy app as smoke test
- Includes models, policies, controllers, migrations, and comprehensive tests