### PR TITLE
Add Strata::US::AlertComponent for USWDS alerts

### DIFF
--- a/app/components/strata/us/alert_component.html.erb
+++ b/app/components/strata/us/alert_component.html.erb
@@ -1,0 +1,10 @@
+<div class="<%= wrapper_classes %>" <%= tag.attributes(@html_attributes) %>>
+  <div class="usa-alert__body">
+    <% if heading? %>
+      <%= content_tag @heading_tag, heading, class: "usa-alert__heading" %>
+    <% end %>
+    <% if body? %>
+      <p class="usa-alert__text"><%= body %></p>
+    <% end %>
+  </div>
+</div>

--- a/app/components/strata/us/alert_component.rb
+++ b/app/components/strata/us/alert_component.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Strata
+  module US
+    # AlertComponent renders a USWDS alert in one of five styles (info, warning,
+    # success, error, emergency) with optional heading, slim variant, and icon.
+    #
+    # @example Basic usage
+    #   <%= render Strata::US::AlertComponent.new(type: :success) do |alert| %>
+    #     <% alert.with_heading { "Saved" } %>
+    #     <% alert.with_body { "Your changes have been saved." } %>
+    #   <% end %>
+    #
+    # @example Slim warning without an icon
+    #   <%= render Strata::US::AlertComponent.new(type: :warning, slim: true, with_icon: false) do |alert| %>
+    #     <% alert.with_body { "Heads up — read-only mode." } %>
+    #   <% end %>
+    class AlertComponent < ViewComponent::Base
+      renders_one :heading
+      renders_one :body
+
+      ALLOWED_TYPES = %i[info warning success error emergency].freeze
+
+      def initialize(
+        type:,
+        slim: false,
+        with_icon: true,
+        heading_tag: :h4,
+        role: nil,
+        classes: nil,
+        **html_attributes
+      )
+        raise ArgumentError, "Invalid type: #{type.inspect}. Must be one of #{ALLOWED_TYPES.inspect}" unless ALLOWED_TYPES.include?(type)
+
+        @type = type
+        @slim = slim
+        @with_icon = with_icon
+        @heading_tag = heading_tag
+        @classes = classes
+        @html_attributes = html_attributes
+        @html_attributes[:role] = role if role
+      end
+
+      def wrapper_classes
+        class_names(
+          "usa-alert",
+          "usa-alert--#{@type}",
+          {
+            "usa-alert--slim" => @slim,
+            "usa-alert--no-icon" => !@with_icon
+          },
+          @classes
+        )
+      end
+    end
+  end
+end

--- a/app/views/strata/tasks/_no_tasks_alert.html.erb
+++ b/app/views/strata/tasks/_no_tasks_alert.html.erb
@@ -1,7 +1,3 @@
-<div class="usa-alert usa-alert--info usa-alert--no-icon">
-  <div class="usa-alert__body">
-    <p class="usa-alert__text">
-      <%= t("strata.tasks.partials.no_tasks_alert.message") %>
-    </p>
-  </div>
-</div>
+<%= render Strata::US::AlertComponent.new(type: :info, with_icon: false) do |alert| %>
+  <% alert.with_body { t("strata.tasks.partials.no_tasks_alert.message") } %>
+<% end %>

--- a/app/views/strata/tasks/show.html.erb
+++ b/app/views/strata/tasks/show.html.erb
@@ -65,13 +65,9 @@
 <%= render partial: "strata/tasks/task_info", locals: { task_info: } %>
 <section class="usa-section padding-top-2">
   <% if flash["task-message"] %>
-    <div class="usa-alert usa-alert--info usa-alert--no-icon">
-      <div class="usa-alert__body">
-        <p class="usa-alert__text">
-          <%= flash["task-message"] %>
-        </p>
-      </div>
-    </div>
+    <%= render Strata::US::AlertComponent.new(type: :info, with_icon: false) do |alert| %>
+      <% alert.with_body { flash["task-message"] } %>
+    <% end %>
   <% end %>
   <% if content_for?(:task_details_partial) %>
     <%= yield(:task_details_partial) %>

--- a/spec/components/strata/us/alert_component_spec.rb
+++ b/spec/components/strata/us/alert_component_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Strata::US::AlertComponent, type: :component do
+  def render_alert(**kwargs, &block)
+    render_inline(described_class.new(**kwargs), &block)
+  end
+
+  describe "default render" do
+    it "renders an info alert with icon, not slim" do
+      render_alert(type: :info) { |a| a.with_body { "Hello" } }
+
+      expect(page).to have_css("div.usa-alert.usa-alert--info")
+      expect(page).not_to have_css(".usa-alert--slim")
+      expect(page).not_to have_css(".usa-alert--no-icon")
+    end
+
+    it "wraps body slot content in p.usa-alert__text inside .usa-alert__body" do
+      render_alert(type: :info) { |a| a.with_body { "Hello world" } }
+
+      expect(page).to have_css(".usa-alert__body p.usa-alert__text", text: "Hello world")
+    end
+
+    it "renders no heading element when heading slot is omitted" do
+      render_alert(type: :info) { |a| a.with_body { "Hello world" } }
+
+      expect(page).not_to have_css(".usa-alert__heading")
+    end
+  end
+
+  describe "type modifier" do
+    %i[info warning success error emergency].each do |type|
+      it "renders usa-alert--#{type} for type: #{type.inspect}" do
+        render_alert(type: type) { |a| a.with_body { "body" } }
+        expect(page).to have_css(".usa-alert.usa-alert--#{type}")
+      end
+    end
+
+    it "raises ArgumentError when type is not one of the allowed symbols" do
+      expect {
+        render_alert(type: :nonsense) { |a| a.with_body { "body" } }
+      }.to raise_error(ArgumentError, /type/)
+    end
+
+    it "raises ArgumentError when type is nil" do
+      expect {
+        render_alert(type: nil) { |a| a.with_body { "body" } }
+      }.to raise_error(ArgumentError, /type/)
+    end
+  end
+
+  describe "slim" do
+    it "adds usa-alert--slim when slim: true" do
+      render_alert(type: :info, slim: true) { |a| a.with_body { "body" } }
+      expect(page).to have_css(".usa-alert.usa-alert--slim")
+    end
+  end
+
+  describe "with_icon" do
+    it "omits usa-alert--no-icon when with_icon: true (default)" do
+      render_alert(type: :info) { |a| a.with_body { "body" } }
+      expect(page).not_to have_css(".usa-alert--no-icon")
+    end
+
+    it "adds usa-alert--no-icon when with_icon: false" do
+      render_alert(type: :info, with_icon: false) { |a| a.with_body { "body" } }
+      expect(page).to have_css(".usa-alert.usa-alert--no-icon")
+    end
+  end
+
+  describe "heading slot" do
+    it "renders h4.usa-alert__heading by default" do
+      render_alert(type: :info) do |a|
+        a.with_heading { "Important" }
+        a.with_body { "body" }
+      end
+      expect(page).to have_css(".usa-alert__body h4.usa-alert__heading", text: "Important")
+    end
+
+    it "uses heading_tag override" do
+      render_alert(type: :info, heading_tag: :h2) do |a|
+        a.with_heading { "Important" }
+        a.with_body { "body" }
+      end
+      expect(page).to have_css("h2.usa-alert__heading", text: "Important")
+    end
+
+    it "allows HTML inside the heading slot" do
+      render_alert(type: :info) do |a|
+        a.with_heading { "<em>Saved</em>".html_safe }
+        a.with_body { "body" }
+      end
+      expect(page).to have_css(".usa-alert__heading em", text: "Saved")
+    end
+  end
+
+  describe "body slot" do
+    it "allows HTML inside the body slot, still wrapped in p.usa-alert__text" do
+      render_alert(type: :info) do |a|
+        a.with_body { "<strong>bold</strong>".html_safe }
+      end
+      expect(page).to have_css("p.usa-alert__text strong", text: "bold")
+    end
+  end
+
+  describe "role" do
+    it "does not set role by default" do
+      render_alert(type: :info) { |a| a.with_body { "body" } }
+      expect(page).not_to have_css(".usa-alert[role]")
+    end
+
+    it "forwards role when specified" do
+      render_alert(type: :error, role: "alert") { |a| a.with_body { "body" } }
+      expect(page).to have_css('.usa-alert[role="alert"]')
+    end
+  end
+
+  describe "extra classes & html attributes" do
+    it "appends classes to the wrapper" do
+      render_alert(type: :info, classes: "margin-top-2 extra") { |a| a.with_body { "body" } }
+      expect(page).to have_css(".usa-alert.usa-alert--info.margin-top-2.extra")
+    end
+
+    it "forwards id, data-*, and aria-* attributes to the wrapper" do
+      render_alert(
+        type: :info,
+        id: "my-alert",
+        data: { test: "yes" },
+        "aria-label": "alerty"
+      ) { |a| a.with_body { "body" } }
+
+      expect(page).to have_css('.usa-alert#my-alert[data-test="yes"][aria-label="alerty"]')
+    end
+  end
+end


### PR DESCRIPTION
## Changes

- Adds `Strata::US::AlertComponent`, a slot-based ViewComponent that renders any of the five USWDS alert variants (info, warning, success, error, emergency).
- Supports `slim:`, `with_icon:`, `heading_tag:`, `role:`, `classes:`, and arbitrary `**html_attributes` forwarded to the wrapping `<div>`.
- Exposes `with_heading` and `with_body` slots. The body slot automatically wraps caller content in `<p class="usa-alert__text">` so callers no longer need to remember that markup.
- Validates `type:` against `ALLOWED_TYPES` and raises `ArgumentError` for invalid values.
- Migrates the two hand-rolled `usa-alert` blocks in the engine to the new component:
  - `app/views/strata/tasks/_no_tasks_alert.html.erb`
  - the `flash["task-message"]` block in `app/views/strata/tasks/show.html.erb`
- Adds `spec/components/strata/us/alert_component_spec.rb` with coverage of types, slim/icon modifiers, heading/body slots, ARIA role passthrough, and extra HTML attribute forwarding.

Closes #253.

## Context

Built off the discussion in #253. A few decisions worth flagging for reviewers:

- **Slot-based API** for `heading` and `body` (rather than string kwargs) so callers don't have to remember `<p class="usa-alert__text">` and can pass arbitrary markup. The body slot wraps content in `p.usa-alert__text` automatically.
- **`with_icon:`** (default `true`) was chosen over `no_icon:` per reviewer preference - reads more naturally at the call site.
- **`role:` is opt-in** rather than auto-derived from `type:`. Whether an alert needs `role="alert"` depends on whether it's dynamic/urgent, and that's context the component can't infer.
- **No `.en.yml` / `.es-US.yml` locale files** - the alert is entirely content-driven by the caller, so there's nothing built-in to translate (same shape as `TableComponent`). Easy to add later if a built-in string ever shows up.
- **No "must have heading or body" guard** - matches the lenient stance `AccordionComponent` takes on slot content. Happy to tighten if preferred.

## Testing

- New spec at `spec/components/strata/us/alert_component_spec.rb` covers the acceptance criteria: each of the five types renders the right `usa-alert--{type}` class, `slim: true` and `with_icon: false` add the right modifier classes, the heading slot renders with the configured tag, the body slot wraps in `p.usa-alert__text`, the role kwarg is forwarded only when supplied, extra `classes:` and `html_attributes` are appended to the wrapper, and invalid/nil `type:` raises `ArgumentError`.
- `make lint` and `make test` were not runnable in the implementation sandbox (no Ruby/bundler). Reviewers: please confirm CI is green before merging.
- Manual check suggested: render the migrated `_no_tasks_alert.html.erb` and the `flash["task-message"]` block in the dummy app to confirm visual parity with the pre-migration markup.

Generated with [Claude Code](https://claude.ai/code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a reusable alert component supporting customizable alert types, optional headings, icons, and styling options for flexible alert displays.

* **Improvements**
  * Updated task page notifications to use the new alert component, ensuring consistent styling and behavior across alert presentations throughout the application.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/navapbc/strata-sdk-rails/pull/335)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->