### PR TITLE
Add prefix/suffix support to text_field; default $ on money_field

### DIFF
--- a/app/helpers/strata/form_builder.rb
+++ b/app/helpers/strata/form_builder.rb
@@ -33,10 +33,12 @@ module Strata
     ########################################
 
     # Override default text fields to automatically include the label,
-    # hint, and error elements
+    # hint, and error elements. Supports USWDS input prefix/suffix via the
+    # +:prefix+ and +:suffix+ options.
     #
     # Example usage:
     #   <%= f.text_field :foobar, { label: "Custom label text", hint: "Some hint text" } %>
+    #   <%= f.text_field :amount, { prefix: "$", suffix: ".00" } %>
     standard_helpers.each do |field_type|
       define_method(field_type) do |attribute, options = {}|
         classes = us_class_for_field_type(field_type, options[:width])
@@ -46,6 +48,8 @@ module Strata
         label_text = options.delete(:label)
         label_class = options.delete(:label_class) || ""
         skip_form_group = options.delete(:skip_form_group)
+        prefix = options.delete(:prefix)
+        suffix = options.delete(:suffix)
 
         label_options = options.except(:width, :class, :id).merge({
           class: label_class,
@@ -57,8 +61,28 @@ module Strata
           field_options[:aria_describedby] = hint_id(attribute)
         end
 
-        content = us_text_field_label(attribute, label_text, label_options) +
-          super(attribute, field_options)
+        input_el = super(attribute, field_options)
+        if prefix || suffix
+          # Rails wraps error-state inputs in <div class="field_with_errors">, which
+          # would sit between the prefix and the input, breaking the
+          # .usa-input-prefix + input CSS adjacency selector that supplies the
+          # input's padding-left. Strip the wrapper only here; Strata renders its
+          # own error markers (usa-input--error, usa-form-group--error, the
+          # usa-error-message span) so nothing visual is lost.
+          if has_error?(attribute)
+            input_el = input_el.to_s.sub(%r{\A<div class="field_with_errors">(.*)</div>\z}m, '\1').html_safe
+          end
+          group_class = "usa-input-group"
+          group_class += " usa-input-group--error" if has_error?(attribute)
+          input_el = @template.content_tag(:div, class: group_class) do
+            @template.safe_join([
+              input_affix(prefix, "usa-input-prefix"),
+              input_el,
+              input_affix(suffix, "usa-input-suffix")
+            ])
+          end
+        end
+        content = us_text_field_label(attribute, label_text, label_options) + input_el
 
         if skip_form_group
           return content
@@ -510,6 +534,8 @@ module Strata
     # @option options [String] :class Custom CSS classes
     # @option options [String] :placeholder Placeholder text
     # @option options [String] :inputmode Input mode (defaults to 'decimal')
+    # @option options [String,FalseClass] :prefix Currency prefix (defaults to '$'; pass +false+ to omit)
+    # @option options [String,FalseClass] :suffix Optional suffix text
     # @return [String] The rendered HTML for the money input
     def money_field(attribute, options = {})
       # Get the existing Money object value if present
@@ -520,6 +546,7 @@ module Strata
       input_options = options.except(:group_options)
       input_options[:inputmode] ||= "decimal"
       input_options[:value] = dollar_value unless input_options.key?(:value)
+      input_options[:prefix] = "$" unless input_options.key?(:prefix)
 
       form_group(attribute, options[:group_options] || {}) do
         text_field(attribute, input_options.merge(skip_form_group: true))
@@ -623,6 +650,11 @@ module Strata
       else
         options[key] = current_value + value
       end
+    end
+
+    def input_affix(text, class_name)
+      return nil unless text
+      @template.content_tag(:div, text, class: class_name, "aria-hidden": true)
     end
 
     def us_class_for_field_type(field_type, width = nil)

--- a/app/helpers/strata/form_builder.rb
+++ b/app/helpers/strata/form_builder.rb
@@ -36,9 +36,16 @@ module Strata
     # hint, and error elements. Supports USWDS input prefix/suffix via the
     # +:prefix+ and +:suffix+ options.
     #
+    # Prefix/suffix elements render with +aria-hidden="true"+ per USWDS
+    # guidance — they are a sighted-user affordance, not part of the input's
+    # accessible name. Callers must ensure the input label carries any
+    # semantic context the affix conveys (e.g. "Income (in dollars)" rather
+    # than "Income" alongside a "$" prefix). See:
+    # https://designsystem.digital.gov/components/input-prefix-suffix/
+    #
     # Example usage:
     #   <%= f.text_field :foobar, { label: "Custom label text", hint: "Some hint text" } %>
-    #   <%= f.text_field :amount, { prefix: "$", suffix: ".00" } %>
+    #   <%= f.text_field :amount, { label: "Amount (in dollars)", prefix: "$" } %>
     standard_helpers.each do |field_type|
       define_method(field_type) do |attribute, options = {}|
         classes = us_class_for_field_type(field_type, options[:width])
@@ -534,8 +541,14 @@ module Strata
     # @option options [String] :class Custom CSS classes
     # @option options [String] :placeholder Placeholder text
     # @option options [String] :inputmode Input mode (defaults to 'decimal')
-    # @option options [String,FalseClass] :prefix Currency prefix (defaults to '$'; pass +false+ to omit)
-    # @option options [String,FalseClass] :suffix Optional suffix text
+    # @option options [String,FalseClass] :prefix Decorative currency prefix
+    #   rendered left-flush inside the input border. Defaults to "$"; pass
+    #   +false+ to omit, or another glyph (e.g. "€"). Marked +aria-hidden+ per
+    #   USWDS — set the label to carry the unit context (e.g.
+    #   "Income (in dollars)") so screen-reader users aren't relying on the
+    #   visual prefix alone.
+    # @option options [String,FalseClass] :suffix Decorative suffix text with
+    #   the same accessibility semantics as +:prefix+.
     # @return [String] The rendered HTML for the money input
     def money_field(attribute, options = {})
       # Get the existing Money object value if present

--- a/app/helpers/strata/form_builder.rb
+++ b/app/helpers/strata/form_builder.rb
@@ -55,8 +55,8 @@ module Strata
         label_text = options.delete(:label)
         label_class = options.delete(:label_class) || ""
         skip_form_group = options.delete(:skip_form_group)
-        prefix = options.delete(:prefix)
-        suffix = options.delete(:suffix)
+        prefix = options.delete(:prefix).presence
+        suffix = options.delete(:suffix).presence
 
         label_options = options.except(:width, :class, :id).merge({
           class: label_class,

--- a/app/helpers/strata/form_builder.rb
+++ b/app/helpers/strata/form_builder.rb
@@ -79,8 +79,7 @@ module Strata
           if has_error?(attribute)
             input_el = input_el.to_s.sub(%r{\A<div class="field_with_errors">(.*)</div>\z}m, '\1').html_safe
           end
-          group_class = "usa-input-group"
-          group_class += " usa-input-group--error" if has_error?(attribute)
+          group_class = us_input_group_class(error: has_error?(attribute), width: options[:width])
           input_el = @template.content_tag(:div, class: group_class) do
             @template.safe_join([
               input_affix(prefix, "usa-input-prefix"),
@@ -687,6 +686,12 @@ module Strata
       end
     end
 
+    def us_input_group_class(error:, width: nil)
+      classes = "usa-input-group"
+      classes += " usa-input-group--error" if error
+      classes += " usa-input-group--#{width}" if width
+      classes
+    end
 
     # Render the label, hint text, and error message for a form field
     def us_text_field_label(attribute, text = nil, options = {})

--- a/app/previews/strata/money_field_preview.rb
+++ b/app/previews/strata/money_field_preview.rb
@@ -31,5 +31,15 @@ module Strata
       model.errors.add(:weekly_wage, :greater_than, value: 0, count: 0)
       render template: "strata/previews/_money_field", locals: { model: model }
     end
+
+    def with_alternate_prefix
+      render template: "strata/previews/_money_field",
+             locals: { model: TestRecord.new, options: { prefix: "€" } }
+    end
+
+    def with_widths
+      render template: "strata/previews/_money_field_widths",
+             locals: { model: TestRecord.new }
+    end
   end
 end

--- a/app/views/strata/previews/_money_field.html.erb
+++ b/app/views/strata/previews/_money_field.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (model:, options: {}) %>
 <%= strata_form_with(model: model, url: false) do |f| %>
-  <%= f.money_field :weekly_wage %>
+  <%= f.money_field :weekly_wage, **options %>
 <% end %>

--- a/app/views/strata/previews/_money_field_widths.html.erb
+++ b/app/views/strata/previews/_money_field_widths.html.erb
@@ -1,0 +1,19 @@
+<%# locals: (model:) %>
+<%= strata_form_with(model: model, url: false) do |f| %>
+  <div class="grid-row grid-gap">
+    <div class="grid-col-6">
+      <h3 class="font-sans-sm">Disabled Prefix</h3>
+      <% %w[xs sm md lg].each do |w| %>
+        <%= f.money_field :weekly_wage, label: "width: #{w}", width: w, prefix: false, id: "control_#{w}" %>
+      <% end %>
+      <%= f.money_field :weekly_wage, label: "no width", prefix: false, id: "control_none" %>
+    </div>
+    <div class="grid-col-6">
+      <h3 class="font-sans-sm">Default Prefix</h3>
+      <% %w[xs sm md lg].each do |w| %>
+        <%= f.money_field :weekly_wage, label: "width: #{w}", width: w, id: "prefixed_#{w}" %>
+      <% end %>
+      <%= f.money_field :weekly_wage, label: "no width", id: "prefixed_none" %>
+    </div>
+  </div>
+<% end %>

--- a/spec/helpers/strata/form_builder_spec.rb
+++ b/spec/helpers/strata/form_builder_spec.rb
@@ -203,6 +203,26 @@ RSpec.describe Strata::FormBuilder do
         expect(result).to have_css('.usa-input-prefix + input')
       end
     end
+
+    context 'with a prefix and a width' do
+      # USWDS forces `.usa-input-group input { width: 100% }`, which overrides
+      # the `usa-input--<width>` max-width on the inner input. The width
+      # modifier has to land on the group itself to constrain the wrapped
+      # input visually.
+      let(:result) { builder.text_field(:income, prefix: '$', width: 'sm') }
+
+      it 'applies the width modifier to the input-group' do
+        expect(result).to have_css('.usa-input-group.usa-input-group--sm')
+      end
+    end
+
+    context 'with a suffix and a width' do
+      let(:result) { builder.text_field(:income, suffix: 'lbs.', width: 'md') }
+
+      it 'applies the width modifier to the input-group' do
+        expect(result).to have_css('.usa-input-group.usa-input-group--md')
+      end
+    end
   end
 
   describe '#hint' do

--- a/spec/helpers/strata/form_builder_spec.rb
+++ b/spec/helpers/strata/form_builder_spec.rb
@@ -804,7 +804,7 @@ RSpec.describe Strata::FormBuilder do
       end
     end
 
-    context 'by default' do
+    context 'without an explicit prefix' do
       it 'wraps the input in a usa-input-group with a $ prefix' do
         expect(result).to have_element(:div, class: 'usa-input-group')
         expect(result).to have_element(:div, text: '$', class: 'usa-input-prefix', 'aria-hidden': 'true')

--- a/spec/helpers/strata/form_builder_spec.rb
+++ b/spec/helpers/strata/form_builder_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Strata::FormBuilder do
       attribute :start_date, :date  # for date_picker
       attribute :has_employer, :string
       attribute :leave_type, :string
+      attribute :income, :string    # for prefix/suffix tests
     end
 
     stub_const("TestForm", test_form_class)
@@ -107,6 +108,71 @@ RSpec.describe Strata::FormBuilder do
 
       it 'adds the class to the label' do
         expect(result).to have_element(:label, class: 'usa-label custom-label-class')
+      end
+    end
+
+    context 'with a prefix' do
+      let(:result) { builder.text_field(:income, prefix: '$') }
+
+      it 'wraps the input in a usa-input-group' do
+        expect(result).to have_element(:div, class: 'usa-input-group')
+      end
+
+      it 'renders the prefix as a sibling of the input, hidden from assistive tech' do
+        expect(result).to have_element(:div, text: '$', class: 'usa-input-prefix', 'aria-hidden': 'true')
+      end
+
+      it 'does not render an input-suffix' do
+        expect(result).not_to have_css('.usa-input-suffix')
+      end
+
+      it 'does not pass the prefix option through to the input element' do
+        expect(result).not_to have_element(:input, prefix: '$')
+      end
+    end
+
+    context 'with a suffix' do
+      let(:result) { builder.text_field(:income, suffix: '.00') }
+
+      it 'wraps the input in a usa-input-group' do
+        expect(result).to have_element(:div, class: 'usa-input-group')
+      end
+
+      it 'renders the suffix as a sibling of the input, hidden from assistive tech' do
+        expect(result).to have_element(:div, text: '.00', class: 'usa-input-suffix', 'aria-hidden': 'true')
+      end
+
+      it 'does not render an input-prefix' do
+        expect(result).not_to have_css('.usa-input-prefix')
+      end
+    end
+
+    context 'with both prefix and suffix' do
+      let(:result) { builder.text_field(:income, prefix: '$', suffix: '.00') }
+
+      it 'renders both affixes inside a single input-group' do
+        expect(result).to have_element(:div, class: 'usa-input-prefix', text: '$')
+        expect(result).to have_element(:div, class: 'usa-input-suffix', text: '.00')
+      end
+    end
+
+    context 'with a prefix and validation errors' do
+      let(:result) { builder.text_field(:income, prefix: '$') }
+
+      before do
+        object.errors.add(:income, 'is invalid')
+      end
+
+      it 'adds the error modifier to the input-group, not just the input' do
+        expect(result).to have_element(:div, class: 'usa-input-group usa-input-group--error')
+      end
+
+      it 'keeps the input as the immediate sibling of the prefix in error states' do
+        # USWDS uses .usa-input-prefix + input (adjacent-sibling selector) to apply
+        # padding-left so the input value doesn't sit on top of the prefix. Anything
+        # that lands between them (e.g. Rails' default field_with_errors wrap) would
+        # break that adjacency.
+        expect(result).to have_css('.usa-input-prefix + input')
       end
     end
   end
@@ -735,6 +801,31 @@ RSpec.describe Strata::FormBuilder do
 
       it 'passes through HTML options to the input' do
         expect(result).to have_element(:input, 'data-test': 'value', 'aria-label': 'Amount')
+      end
+    end
+
+    context 'by default' do
+      it 'wraps the input in a usa-input-group with a $ prefix' do
+        expect(result).to have_element(:div, class: 'usa-input-group')
+        expect(result).to have_element(:div, text: '$', class: 'usa-input-prefix', 'aria-hidden': 'true')
+      end
+    end
+
+    context 'with an explicit prefix' do
+      let(:result) { builder.money_field(:weekly_wage, prefix: '€') }
+
+      it 'uses the caller-supplied prefix instead of the default' do
+        expect(result).to have_element(:div, text: '€', class: 'usa-input-prefix')
+        expect(result).not_to have_element(:div, text: '$', class: 'usa-input-prefix')
+      end
+    end
+
+    context 'with prefix: false' do
+      let(:result) { builder.money_field(:weekly_wage, prefix: false) }
+
+      it 'omits the input-group wrapper and the prefix entirely' do
+        expect(result).not_to have_css('.usa-input-group')
+        expect(result).not_to have_css('.usa-input-prefix')
       end
     end
   end

--- a/spec/helpers/strata/form_builder_spec.rb
+++ b/spec/helpers/strata/form_builder_spec.rb
@@ -156,6 +156,34 @@ RSpec.describe Strata::FormBuilder do
       end
     end
 
+    context 'with a blank prefix' do
+      let(:result) { builder.text_field(:income, prefix: '') }
+
+      it 'treats an empty string as absent and does not wrap the input' do
+        expect(result).not_to have_css('.usa-input-group')
+        expect(result).not_to have_css('.usa-input-prefix')
+      end
+    end
+
+    context 'with a blank suffix' do
+      let(:result) { builder.text_field(:income, suffix: '') }
+
+      it 'treats an empty string as absent and does not wrap the input' do
+        expect(result).not_to have_css('.usa-input-group')
+        expect(result).not_to have_css('.usa-input-suffix')
+      end
+    end
+
+    context 'with a present prefix and a blank suffix' do
+      let(:result) { builder.text_field(:income, prefix: '$', suffix: '') }
+
+      it 'wraps the input but omits the empty suffix entirely' do
+        expect(result).to have_css('.usa-input-group')
+        expect(result).to have_element(:div, class: 'usa-input-prefix', text: '$')
+        expect(result).not_to have_css('.usa-input-suffix')
+      end
+    end
+
     context 'with a prefix and validation errors' do
       let(:result) { builder.text_field(:income, prefix: '$') }
 


### PR DESCRIPTION
## Summary

Adds USWDS [Input prefix/suffix] support to `Strata::FormBuilder#text_field` via new `:prefix` and `:suffix` options, and defaults `money_field` to a `$` prefix. Motivated by [OSCER-351](https://github.com/navapbc/oscer/issues/351), where the income activity form renders a bare number input with no currency indicator while the review screen formats values with `$`.

[Input prefix/suffix]: https://designsystem.digital.gov/components/input-prefix-suffix/

## Changes

- `text_field` (and all `standard_helpers` it shares the override loop with) accept `:prefix` / `:suffix`. When set, the input is wrapped in a `usa-input-group` with sibling `usa-input-prefix` / `usa-input-suffix` divs.
- `money_field` defaults to `prefix: "$"`. Callers can override (`prefix: "€"`) or opt out entirely (`prefix: false`).
- New private helper `input_affix` builds the affix divs with `aria-hidden="true"` — screen readers skip the decorative glyph and rely on the input's label for currency context. Consumers should ensure currency-bearing labels read naturally (e.g. _Income (in dollars)_).
- Error-state handling: `usa-input-group--error` is applied to the group (matching USWDS markup), and Rails' default `field_with_errors` wrapper is stripped from the input. Without that strip, the extra `<div>` sits between `.usa-input-prefix` and `<input>`, breaking the `.usa-input-prefix + input` CSS adjacency selector that supplies the input's `padding-left` — and the input value renders flush against the prefix glyph.

## Discussion / open question

Why push it into `text_field` and not just `money_field`? USWDS treats prefix/suffix as a generic input modifier. Phone fields, percentages, units — any text-style input might want one. Adding it once in the shared `standard_helpers` loop means future callers get it for free; `money_field` becomes "a text input with sensible currency defaults."

The error-state fix here strips `field_with_errors` only for prefixed/suffixed inputs. The broader option is to set `ActionView::Base.field_error_proc` to a pass-through in the engine.

- It seems Strata already renders its own error markers (`usa-input--error`, `usa-form-group--error`, `usa-error-message` span), making the Rails wrapper is purely redundant for any Strata consumer. Is this a valid conclusion?
- Should the decision of what to do about `field_with_errors` be recorded in an ADR?

Applying the broad fix would preempt the same bug class for future USWDS adjacency selectors (character counters, etc.).

I held back the scope on this PR because it changes rendered HTML for every Strata consumer in error states. Would appreciate input here on the questions above and, if desired, whether the more broadly-scoped change should land here in this PR or as a follow-up.

## Test plan

- [x] `bundle exec rspec spec/helpers/strata/form_builder_spec.rb` (12 new contexts)
- [x] `bundle exec rspec spec/helpers spec/models spec/components spec/services spec/lib`
- [x] Lookbook visual check on `Strata::MoneyFieldPreview` for `empty`, `filled`, and `invalid` states. `$` renders left-flush inside the input border, input value has correct padding, group border escalates to red in error state
- [x] Wired into OSCER reporting-app via bundler local override and walked the income activity flow end-to-end.

## Consumer impact

`money_field` rendered HTML changes for all Strata consumers: the input is now wrapped in `usa-input-group` and gets a `$` prefix unless `prefix: false` is passed. Form submission semantics, params, and validation behavior are unchanged.

For non-money `text_field` callers there is zero change. The `:prefix` / `:suffix` options are opt-in.