### PR TITLE
Create claude sandbox instructions

### DIFF
--- a/.github/claude-sandbox-instructions.md
+++ b/.github/claude-sandbox-instructions.md
@@ -12,7 +12,7 @@ You can confirm you're in this context by checking that `$GITHUB_ACTIONS == "tru
    - Test approach
    - Any open questions or assumptions
 
-   Then stop and wait. Do not start coding until a human replies with approval (e.g. "go ahead", "lgtm", or answers your questions). Once approved, proceed through the rest of the workflow autonomously — you do not need further sign-off for individual decisions along the way unless you hit one of the items in "When to stop and ask" below.
+   Then stop and wait. Do not start coding until a human replies with approval. **The reply must mention `@claude`** (e.g. `@claude go ahead`, `@claude lgtm`) — the workflow only fires on comments containing that mention, so a bare "go ahead" will not re-trigger a run. Once approved, proceed through the rest of the workflow autonomously — you do not need further sign-off for individual decisions along the way unless you hit one of the items in "When to stop and ask" below.
 
 2. **Work on a branch.** Create a branch off the appropriate base:
    - Issue trigger → branch off the default branch

--- a/.github/claude-sandbox-instructions.md
+++ b/.github/claude-sandbox-instructions.md
@@ -6,17 +6,19 @@ You can confirm you're in this context by checking that `$GITHUB_ACTIONS == "tru
 
 ## Workflow for changes
 
-1. **Plan first, then wait for approval.** Post a comment on the triggering issue/PR with:
+1. **Post a plan and wait for approval.** Comment on the triggering issue/PR with:
    - What you'll change and why
    - Files you expect to touch
    - Test approach
    - Any open questions or assumptions
-     Then stop. Do not start coding until a human replies with approval (e.g. "go ahead", "lgtm", or answers your questions). If the trigger comment already contains a clear, detailed instruction, you can post a short confirmation plan and proceed once a human acknowledges — but when in doubt, wait.
 
-2. **Work on a branch.** Once approved, create a branch off the appropriate base:
+   Then stop and wait. Do not start coding until a human replies with approval (e.g. "go ahead", "lgtm", or answers your questions). Once approved, proceed through the rest of the workflow autonomously — you do not need further sign-off for individual decisions along the way unless you hit one of the items in "When to stop and ask" below.
+
+2. **Work on a branch.** Create a branch off the appropriate base:
    - Issue trigger → branch off the default branch
    - PR/review trigger → branch off the PR's head branch
-     Use a descriptive name like `claude/<short-description>`. Never push directly to `main`.
+
+   Use a descriptive name like `claude/<short-description>`. Never push directly to `main`.
 
 3. **Implement.** Follow every rule in [CLAUDE.md](../CLAUDE.md).
 
@@ -32,16 +34,17 @@ You can confirm you're in this context by checking that `$GITHUB_ACTIONS == "tru
 
 ## When to stop and ask
 
+Only stop for **major** items that genuinely require human judgment. For everything else, make a reasoned choice, document it in the PR description, and let code review catch any disagreement.
+
 You cannot truly pause mid-run in CI, so "stop and ask" means: **post a comment summarizing the situation, list the options you see with trade-offs, and exit without making further code changes.** Do this when you hit:
 
-- An ambiguous business rule that [CLAUDE.md](../CLAUDE.md) says to ask about
+- A business rule you can't infer from existing code, tests, or the triggering comment
 - A breaking API or schema change that affects callers outside the changeset
-- A failing test whose root cause is unclear, or that you can't reproduce reasoning about
-- A decision between two valid implementation paths with materially different trade-offs
+- A failing test you cannot diagnose after reasonable investigation
 - Anything that would require modifying CI, secrets, deployment config, or other shared infra
 - A request whose scope is materially larger than the triggering comment implies
 
-A clear "here are the options, please pick" comment is far more useful than a confident wrong direction.
+A clear "here are the options, please pick" comment is far more useful than a confident wrong direction — but reserve it for the items above, not every fork in the road.
 
 ## Communication style
 

--- a/.github/claude-sandbox-instructions.md
+++ b/.github/claude-sandbox-instructions.md
@@ -1,0 +1,51 @@
+# Claude Sandbox Instructions
+
+These rules apply **only when Claude is running in GitHub Actions** (triggered via [.github/workflows/claude.yml](workflows/claude.yml), typically by an `@claude` mention on an issue, PR, or review comment). They layer on top of [CLAUDE.md](../CLAUDE.md) — every rule there still applies.
+
+You can confirm you're in this context by checking that `$GITHUB_ACTIONS == "true"`.
+
+## Workflow for changes
+
+1. **Plan first, then wait for approval.** Post a comment on the triggering issue/PR with:
+   - What you'll change and why
+   - Files you expect to touch
+   - Test approach
+   - Any open questions or assumptions
+     Then stop. Do not start coding until a human replies with approval (e.g. "go ahead", "lgtm", or answers your questions). If the trigger comment already contains a clear, detailed instruction, you can post a short confirmation plan and proceed once a human acknowledges — but when in doubt, wait.
+
+2. **Work on a branch.** Once approved, create a branch off the appropriate base:
+   - Issue trigger → branch off the default branch
+   - PR/review trigger → branch off the PR's head branch
+     Use a descriptive name like `claude/<short-description>`. Never push directly to `main`.
+
+3. **Implement.** Follow every rule in [CLAUDE.md](../CLAUDE.md).
+
+4. **Verify before pushing.** Run `make lint` and `make test`. Resolve every failure. Never push a branch with failing lint or tests.
+
+5. **Open a PR with a real description.** Title summarizes the change in under 70 chars. Body follows [PR template](./pull_request_template.md) and also includes:
+   - **Open questions** — anything you decided but want human review on
+   - A link back to the triggering issue or comment
+
+## Main branch
+
+**Never** commit, push, or merge changes to the `main` branch. All work must be done on a separate branch. Only humans may commit, push, or merge changes to `main`.
+
+## When to stop and ask
+
+You cannot truly pause mid-run in CI, so "stop and ask" means: **post a comment summarizing the situation, list the options you see with trade-offs, and exit without making further code changes.** Do this when you hit:
+
+- An ambiguous business rule that [CLAUDE.md](../CLAUDE.md) says to ask about
+- A breaking API or schema change that affects callers outside the changeset
+- A failing test whose root cause is unclear, or that you can't reproduce reasoning about
+- A decision between two valid implementation paths with materially different trade-offs
+- Anything that would require modifying CI, secrets, deployment config, or other shared infra
+- A request whose scope is materially larger than the triggering comment implies
+
+A clear "here are the options, please pick" comment is far more useful than a confident wrong direction.
+
+## Communication style
+
+- Be concise. The reader is reviewing a diff, not reading prose.
+- Don't reproduce the diff in plan or PR text — link to it.
+- If a decision was non-obvious, explain _why_ in one or two sentences. Don't explain _what_.
+- Surface anything you skipped, deferred, or are unsure about. Don't hide it at the bottom.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,10 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Claude reads CLAUDE.md from the checked-out repo automatically, and CLAUDE.md
+      # points at .github/claude-sandbox-instructions.md for CI-specific workflow rules
+      # (plan-then-approve, branch + PR flow, stop-and-comment on hard decisions).
+      # Edit that file to change how Claude behaves in CI.
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,12 @@ For non-trivial work, follow these steps in order:
 
 When in doubt about whether a change is trivial, ask.
 
+## Execution context
+
+When you are running in GitHub Actions (typically triggered by an `@claude` mention on an issue, PR, or review comment), **additionally** follow [.github/claude-sandbox-instructions.md](.github/claude-sandbox-instructions.md). Those rules cover the CI-specific workflow: post a plan and wait for approval, work on a branch, open a PR with a description, and post-a-comment-then-stop when you hit decisions that need human judgment.
+
+Check `$GITHUB_ACTIONS` (set to `true` in CI) if you're unsure which context you're in. When running locally, ignore the sandbox instructions.
+
 ## Migrations
 
 Generate migrations with the Rails generator from inside the dummy app:


### PR DESCRIPTION
## Changes

- Add specific instructions for Claude workflows

## Context

- Trying to add instructions specifically for Claude while it's working on a ticket or other sandbox item

## Testing

- CI passes
