### PR TITLE
Add Strata::US::ListComponent

### DIFF
--- a/app/components/strata/us/list_component.html.erb
+++ b/app/components/strata/us/list_component.html.erb
@@ -1,0 +1,5 @@
+<%= content_tag list_tag, class: list_classes, **@html_attributes do %>
+  <% items.each do |item| %>
+    <%= item %>
+  <% end %>
+<% end %>

--- a/app/components/strata/us/list_component.rb
+++ b/app/components/strata/us/list_component.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Strata
+  module US
+    # ListComponent renders a USWDS-styled list as either a <ul> or <ol>,
+    # with optional unstyled (no markers, no indent) modifier.
+    #
+    # @example Basic unordered list
+    #   <%= render Strata::US::ListComponent.new do |list| %>
+    #     <% list.with_item { "First" } %>
+    #     <% list.with_item { "Second" } %>
+    #   <% end %>
+    #
+    # @example Ordered list
+    #   <%= render Strata::US::ListComponent.new(ordered: true) do |list| %>
+    #     <% list.with_item { "First" } %>
+    #   <% end %>
+    #
+    # @example Passing a collection of items
+    #   <%= render Strata::US::ListComponent.new do |list| %>
+    #     <% list.with_items(["Apples", "Bananas", "Cherries"]) %>
+    #   <% end %>
+    #
+    # @example Unstyled (no markers, no indent)
+    #   <%= render Strata::US::ListComponent.new(unstyled: true) do |list| %>
+    #     <% list.with_item { "First" } %>
+    #   <% end %>
+    class ListComponent < ViewComponent::Base
+      renders_many :items, "Strata::US::ListComponent::ItemComponent"
+
+      def initialize(ordered: false, unstyled: false, classes: nil, **html_attributes)
+        @ordered = ordered
+        @unstyled = unstyled
+        @classes = classes
+        @html_attributes = html_attributes
+      end
+
+      def list_tag
+        @ordered ? :ol : :ul
+      end
+
+      def list_classes
+        class_names(
+          "usa-list",
+          { "usa-list--unstyled" => @unstyled },
+          @classes
+        )
+      end
+
+      # Renders an individual list item (<li>). Accepts content as a positional
+      # argument (used by ViewComponent's collection-passing via `with_items`)
+      # or as a block (used by `with_item { ... }`).
+      class ItemComponent < ViewComponent::Base
+        def initialize(text = nil, classes: nil, **html_attributes)
+          @text = text
+          @classes = classes
+          @html_attributes = html_attributes
+        end
+
+        def call
+          content_tag :li, (content || @text), class: @classes, **@html_attributes
+        end
+      end
+    end
+  end
+end

--- a/app/previews/strata/us/list_component_preview.rb
+++ b/app/previews/strata/us/list_component_preview.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Strata
+  module US
+    # ListComponentPreview provides preview examples for the Strata::US::ListComponent.
+    class ListComponentPreview < Lookbook::Preview
+      layout "strata/component_preview"
+
+      # @label Unordered List
+      def unordered
+        render Strata::US::ListComponent.new do |list|
+          list.with_item { "Unordered list item" }
+          list.with_item { "Unordered list item" }
+          list.with_item { "Unordered list item" }
+        end
+      end
+
+      # @label Ordered List
+      def ordered
+        render Strata::US::ListComponent.new(ordered: true) do |list|
+          list.with_item { "Ordered list item" }
+          list.with_item { "Ordered list item" }
+          list.with_item { "Ordered list item" }
+        end
+      end
+
+      # @label Unstyled List
+      def unstyled
+        render Strata::US::ListComponent.new(unstyled: true) do |list|
+          list.with_item { "Unstyled list item" }
+          list.with_item { "Unstyled list item" }
+          list.with_item { "Unstyled list item" }
+        end
+      end
+
+      # @label Collection-passed Items
+      def from_collection
+        render Strata::US::ListComponent.new do |list|
+          list.with_items([ "Apples", "Bananas", "Cherries", "Dates" ])
+        end
+      end
+
+      # @label Nested List
+      # Renders via the sibling `nested.html.erb` template — nested `render` calls don't work inside slot blocks in a Lookbook preview method.
+      def nested; end
+    end
+  end
+end

--- a/app/previews/strata/us/list_component_preview/nested.html.erb
+++ b/app/previews/strata/us/list_component_preview/nested.html.erb
@@ -1,0 +1,11 @@
+<%= render Strata::US::ListComponent.new do |outer| %>
+  <% outer.with_item { "First top-level item" } %>
+  <% outer.with_item do %>
+    Second top-level item with a nested list:
+    <%= render Strata::US::ListComponent.new do |inner| %>
+      <% inner.with_item { "Nested item A" } %>
+      <% inner.with_item { "Nested item B" } %>
+    <% end %>
+  <% end %>
+  <% outer.with_item { "Third top-level item" } %>
+<% end %>

--- a/spec/components/strata/us/list_component_spec.rb
+++ b/spec/components/strata/us/list_component_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Strata::US::ListComponent, type: :component do
+  it "renders an unordered list by default" do
+    render_inline(described_class.new) do |list|
+      list.with_item { "First" }
+      list.with_item { "Second" }
+    end
+
+    expect(page).to have_css("ul.usa-list")
+    expect(page).not_to have_css("ol")
+    expect(page).to have_css("ul.usa-list > li", count: 2)
+    expect(page).to have_css("li", text: "First")
+    expect(page).to have_css("li", text: "Second")
+  end
+
+  it "renders an ordered list when ordered: true" do
+    render_inline(described_class.new(ordered: true)) do |list|
+      list.with_item { "First" }
+      list.with_item { "Second" }
+    end
+
+    expect(page).to have_css("ol.usa-list")
+    expect(page).not_to have_css("ul")
+    expect(page).to have_css("ol.usa-list > li", count: 2)
+  end
+
+  it "applies the unstyled modifier when unstyled: true" do
+    render_inline(described_class.new(unstyled: true)) do |list|
+      list.with_item { "First" }
+    end
+
+    expect(page).to have_css("ul.usa-list.usa-list--unstyled")
+  end
+
+  it "does not apply the unstyled modifier by default" do
+    render_inline(described_class.new) do |list|
+      list.with_item { "First" }
+    end
+
+    expect(page).not_to have_css(".usa-list--unstyled")
+  end
+
+  it "combines ordered and unstyled" do
+    render_inline(described_class.new(ordered: true, unstyled: true)) do |list|
+      list.with_item { "First" }
+    end
+
+    expect(page).to have_css("ol.usa-list.usa-list--unstyled")
+  end
+
+  it "applies additional classes to the root element" do
+    render_inline(described_class.new(classes: "my-extra-class")) do |list|
+      list.with_item { "First" }
+    end
+
+    expect(page).to have_css("ul.usa-list.my-extra-class")
+  end
+
+  it "passes html attributes to the root element" do
+    render_inline(described_class.new(id: "my-list", data: { foo: "bar" })) do |list|
+      list.with_item { "First" }
+    end
+
+    expect(page).to have_css("ul#my-list.usa-list[data-foo='bar']")
+  end
+
+  it "applies item-level classes to each li" do
+    render_inline(described_class.new) do |list|
+      list.with_item(classes: "highlighted") { "First" }
+      list.with_item { "Second" }
+    end
+
+    expect(page).to have_css("li.highlighted", text: "First")
+    expect(page).not_to have_css("li.highlighted", text: "Second")
+  end
+
+  it "passes item-level html attributes to each li" do
+    render_inline(described_class.new) do |list|
+      list.with_item(id: "item-1", data: { index: "1" }) { "First" }
+    end
+
+    expect(page).to have_css("li#item-1[data-index='1']", text: "First")
+  end
+
+  it "renders empty when no items are added" do
+    render_inline(described_class.new)
+
+    expect(page).to have_css("ul.usa-list")
+    expect(page).not_to have_css("li")
+  end
+
+  describe "collection-passing via with_items" do
+    it "renders one li per element when passed an array of strings" do
+      items = [ "Apples", "Bananas", "Cherries" ]
+
+      render_inline(described_class.new) do |list|
+        list.with_items(items)
+      end
+
+      expect(page).to have_css("ul.usa-list > li", count: 3)
+      expect(page).to have_css("li", text: "Apples")
+      expect(page).to have_css("li", text: "Bananas")
+      expect(page).to have_css("li", text: "Cherries")
+    end
+
+    it "preserves order of items in the collection" do
+      render_inline(described_class.new(ordered: true)) do |list|
+        list.with_items([ "One", "Two", "Three" ])
+      end
+
+      rendered_text = page.all("li").map(&:text)
+      expect(rendered_text).to eq([ "One", "Two", "Three" ])
+    end
+
+    it "can be combined with with_item calls" do
+      render_inline(described_class.new) do |list|
+        list.with_items([ "From array A", "From array B" ])
+        list.with_item { "Individual" }
+      end
+
+      expect(page).to have_css("li", count: 3)
+      expect(page).to have_css("li", text: "From array A")
+      expect(page).to have_css("li", text: "From array B")
+      expect(page).to have_css("li", text: "Individual")
+    end
+
+    it "renders nothing extra when given an empty collection" do
+      render_inline(described_class.new) do |list|
+        list.with_items([])
+      end
+
+      expect(page).to have_css("ul.usa-list")
+      expect(page).not_to have_css("li")
+    end
+  end
+
+  describe "nested lists" do
+    it "supports nesting by rendering arbitrary block content inside an item" do
+      render_inline(described_class.new) do |outer|
+        outer.with_item do
+          "Parent item"
+        end
+      end
+
+      expect(page).to have_css("ul.usa-list > li", text: "Parent item")
+    end
+  end
+end

--- a/spec/components/strata/us/list_component_spec.rb
+++ b/spec/components/strata/us/list_component_spec.rb
@@ -138,14 +138,22 @@ RSpec.describe Strata::US::ListComponent, type: :component do
   end
 
   describe "nested lists" do
-    it "supports nesting by rendering arbitrary block content inside an item" do
+    it "renders a child ListComponent inside an item" do
+      inner_html = render_inline(described_class.new(ordered: true)) do |inner|
+        inner.with_item { "Nested 1" }
+        inner.with_item { "Nested 2" }
+      end.to_html
+
       render_inline(described_class.new) do |outer|
-        outer.with_item do
-          "Parent item"
-        end
+        outer.with_item { "Top-level A" }
+        outer.with_item { inner_html.html_safe }
       end
 
-      expect(page).to have_css("ul.usa-list > li", text: "Parent item")
+      expect(page).to have_css("ul.usa-list > li", text: "Top-level A")
+      expect(page).to have_css("ul.usa-list > li > ol.usa-list")
+      expect(page).to have_css("ul.usa-list > li > ol.usa-list > li", count: 2)
+      expect(page).to have_css("ul.usa-list > li > ol.usa-list > li", text: "Nested 1")
+      expect(page).to have_css("ul.usa-list > li > ol.usa-list > li", text: "Nested 2")
     end
   end
 end


### PR DESCRIPTION
Closes #255

## Summary

Adds `Strata::US::ListComponent`, a ViewComponent that renders a USWDS-styled `<ul>` or `<ol>`, modeled on the existing `AccordionComponent` and `TableComponent`.

- `ordered:` toggles `<ul>` ↔ `<ol>`
- `unstyled:` applies `usa-list--unstyled` (no markers, no indent)
- `classes:` + arbitrary HTML attributes pass through to the root element
- Per-item `classes:` and HTML attributes pass through to each `<li>`
- Collection-passing: `list.with_items(["a", "b"])` renders one `<li>` per element
- Mix-and-match: `with_items(array)` and `with_item { ... }` can be combined

## Test plan

- [ ] `make test` passes locally (15 new examples in `spec/components/strata/us/list_component_spec.rb`)
- [ ] `make lint` passes locally
- [ ] Render the component in the dummy app and visually confirm USWDS styling

🤖 Generated with [Claude Code](https://claude.ai/code)