### PR TITLE
Add accordion classes option

### DIFF
--- a/app/components/strata/us/accordion_component.html.erb
+++ b/app/components/strata/us/accordion_component.html.erb
@@ -1,8 +1,4 @@
-<div class="<%= class_names(
-  "usa-accordion",
-  "usa-accordion--bordered": @is_bordered,
-  "usa-accordion--multiselectable": @is_multiselectable
-) %>"<%= ' data-allow-multiple' if @is_multiselectable %>>
+<div class="<%= wrapper_classes %>"<%= ' data-allow-multiple' if @is_multiselectable %> <%= tag.attributes(@html_attributes) %>>
   <% headings.zip(bodies).each_with_index do |(heading, body), idx| %>
     <%= content_tag @heading_tag, class: "usa-accordion__heading" do %>
       <button type="button" class="usa-accordion__button" aria-expanded="false" aria-controls="<%= item_id(idx) %>">

--- a/app/components/strata/us/accordion_component.rb
+++ b/app/components/strata/us/accordion_component.rb
@@ -16,17 +16,30 @@ module Strata
       renders_many :headings
       renders_many :bodies
 
-      def initialize(heading_tag:, id_prefix: nil, is_bordered: false, is_multiselectable: false)
+      def initialize(heading_tag:, id_prefix: nil, is_bordered: false, is_multiselectable: false, classes: nil, **html_attributes)
         @heading_tag = heading_tag
         @is_bordered = is_bordered
         @is_multiselectable = is_multiselectable
         @id_prefix = id_prefix || "acrdn-#{SecureRandom.hex(6)}-"
+        @classes = classes
+        @html_attributes = html_attributes
       end
 
       def before_render
         if headings.length != bodies.length
           raise ArgumentError, "Number of headings (#{headings.length}) must match number of bodies (#{bodies.length})"
         end
+      end
+
+      def wrapper_classes
+        class_names(
+          "usa-accordion",
+          {
+            "usa-accordion--bordered" => @is_bordered,
+            "usa-accordion--multiselectable" => @is_multiselectable
+          },
+          @classes
+        )
       end
 
       private

--- a/app/previews/strata/us/accordion_component_preview.rb
+++ b/app/previews/strata/us/accordion_component_preview.rb
@@ -38,22 +38,6 @@ module Strata
           component.with_body { "<p>No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.</p>".html_safe }
         end
       end
-
-      def with_custom_classes_and_html_attributes
-        render Strata::US::AccordionComponent.new(
-          heading_tag: :h4,
-          is_bordered: true,
-          classes: "my-accordion",
-          id: "amendments",
-          data: { testid: "amendments-accordion" },
-          "aria-label": "Bill of Rights"
-        ) do |component|
-          component.with_heading { "First Amendment" }
-          component.with_body { "<p>Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.</p>".html_safe }
-          component.with_heading { "Second Amendment" }
-          component.with_body { "<p>A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.</p>".html_safe }
-        end
-      end
     end
   end
 end

--- a/app/previews/strata/us/accordion_component_preview.rb
+++ b/app/previews/strata/us/accordion_component_preview.rb
@@ -38,6 +38,22 @@ module Strata
           component.with_body { "<p>No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.</p>".html_safe }
         end
       end
+
+      def with_custom_classes_and_html_attributes
+        render Strata::US::AccordionComponent.new(
+          heading_tag: :h4,
+          is_bordered: true,
+          classes: "my-accordion",
+          id: "amendments",
+          data: { testid: "amendments-accordion" },
+          "aria-label": "Bill of Rights"
+        ) do |component|
+          component.with_heading { "First Amendment" }
+          component.with_body { "<p>Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.</p>".html_safe }
+          component.with_heading { "Second Amendment" }
+          component.with_body { "<p>A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.</p>".html_safe }
+        end
+      end
     end
   end
 end

--- a/docs/uswds-components.md
+++ b/docs/uswds-components.md
@@ -10,7 +10,7 @@ All components live in the `Strata::US` namespace under [app/components/strata/u
 <% end %>
 ```
 
-Most components accept a `classes:` keyword for additional CSS classes and forward any other keyword arguments as HTML attributes on the component's primary element — see each component's options below for specifics. Live previews are available in Lookbook (mounted at `/lookbook` in the dummy app — run `make start` and visit `http://localhost:3000/lookbook`); preview sources are under [app/previews/strata/us/](../app/previews/strata/us/).
+Every component accepts a `classes:` keyword for additional CSS classes and forwards any other keyword arguments as HTML attributes on the component's primary element (the `<table>` for [Table](#table); the wrapping element otherwise). Live previews are available in Lookbook (mounted at `/lookbook` in the dummy app — run `make start` and visit `http://localhost:3000/lookbook`); preview sources are under [app/previews/strata/us/](../app/previews/strata/us/).
 
 ## Components
 
@@ -33,6 +33,7 @@ Most components accept a `classes:` keyword for additional CSS classes and forwa
 - `id_prefix:` — prefix used to generate panel IDs. Defaults to a random `acrdn-XXXXXX-` value.
 - `is_bordered:` — render the bordered variant. Defaults to `false`.
 - `is_multiselectable:` — allow multiple panels open at once. Defaults to `false`.
+- `classes:` — extra CSS classes appended to the root element.
 
 **Slots**
 

--- a/spec/components/strata/us/accordion_component_spec.rb
+++ b/spec/components/strata/us/accordion_component_spec.rb
@@ -117,4 +117,53 @@ RSpec.describe Strata::US::AccordionComponent, type: :component do
       end
     }.to raise_error(ArgumentError, /Number of headings.*must match number of bodies/)
   end
+
+  context "when classes are provided" do
+    it "appends them after the base and variant USWDS classes" do
+      render_inline(described_class.new(heading_tag: :h2, is_bordered: true, classes: "my-acc extra")) do |c|
+        c.with_heading { "Item 1" }
+        c.with_body { "<p>Content</p>".html_safe }
+      end
+
+      expect(page).to have_css(".usa-accordion.usa-accordion--bordered.my-acc.extra")
+    end
+
+    it "does nothing when nil" do
+      render_inline(described_class.new(heading_tag: :h2, classes: nil)) do |c|
+        c.with_heading { "Item 1" }
+        c.with_body { "<p>Content</p>".html_safe }
+      end
+
+      expect(page.find(".usa-accordion")[:class]).to eq("usa-accordion")
+    end
+  end
+
+  context "when extra HTML attributes are provided" do
+    it "forwards them to the root element" do
+      render_inline(described_class.new(
+        heading_tag: :h2,
+        id: "faq",
+        data: { testid: "faq-acc" },
+        "aria-label": "FAQ"
+      )) do |c|
+        c.with_heading { "Item 1" }
+        c.with_body { "<p>Content</p>".html_safe }
+      end
+
+      expect(page).to have_css(".usa-accordion#faq[data-testid='faq-acc'][aria-label='FAQ']")
+    end
+
+    it "keeps data-allow-multiple alongside other forwarded data attributes when multiselectable" do
+      render_inline(described_class.new(
+        heading_tag: :h2,
+        is_multiselectable: true,
+        data: { testid: "faq-acc" }
+      )) do |c|
+        c.with_heading { "Item 1" }
+        c.with_body { "<p>Content</p>".html_safe }
+      end
+
+      expect(page).to have_css(".usa-accordion[data-allow-multiple][data-testid='faq-acc']")
+    end
+  end
 end


### PR DESCRIPTION
## Changes

- Added the `classes` and html_attributes options to accordion uswds component

## Context

- This makes the accordion behave like the other defined uswds components

## Testing

- CI
