### PR TITLE
Fix flaky task_info view spec on names with apostrophes

### DIFF
--- a/spec/views/strata/tasks/_task_info.html.erb_spec.rb
+++ b/spec/views/strata/tasks/_task_info.html.erb_spec.rb
@@ -35,12 +35,12 @@ RSpec.describe "strata/tasks/_task_info.html.erb", type: :view do
 
     it "renders each info item correctly" do
       expect(rendered).to have_selector('div.grid-col-auto', count: 3)
-      expect(rendered).to include(task_info[0][:label])
-      expect(rendered).to include(task_info[0][:value])
-      expect(rendered).to include(task_info[1][:label])
-      expect(rendered).to include(task_info[1][:value])
-      expect(rendered).to include(task_info[2][:label])
-      expect(rendered).to include(task_info[2][:value])
+      expect(rendered).to have_content(task_info[0][:label])
+      expect(rendered).to have_content(task_info[0][:value])
+      expect(rendered).to have_content(task_info[1][:label])
+      expect(rendered).to have_content(task_info[1][:value])
+      expect(rendered).to have_content(task_info[2][:label])
+      expect(rendered).to have_content(task_info[2][:value])
     end
   end
 end


### PR DESCRIPTION
## Summary

- `Faker::Name.name` occasionally produces names containing an apostrophe (e.g. `Rep. Kamilah O'Hara`). The rendered ERB escapes these as `&#39;`, but the spec was asserting against the raw string with `include`, causing intermittent CI failures.
- Switched the array-of-hashes context in `spec/views/strata/tasks/_task_info.html.erb_spec.rb` from `expect(rendered).to include(...)` to `expect(rendered).to have_content(...)`, which decodes HTML entities and compares visible text — the right level of abstraction for a view spec.
- Left the `content_for` context untouched: its content is injected via `html_safe`, so no escaping occurs, and `Faker::Alphanumeric.alpha` / `Faker::Lorem.sentence` don't produce HTML-special characters anyway.

## Test plan

- [x] `bundle exec rspec spec/views/strata/tasks/_task_info.html.erb_spec.rb` passes locally
- [x] Spec passes across 10 different random seeds
- [x] Full suite (`make test`) passes: 1300 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)