### PR TITLE
Disable Rails `field_with_errors` wrapper

### DIFF
--- a/app/helpers/strata/form_builder.rb
+++ b/app/helpers/strata/form_builder.rb
@@ -70,15 +70,6 @@ module Strata
 
         input_el = super(attribute, field_options)
         if prefix || suffix
-          # Rails wraps error-state inputs in <div class="field_with_errors">, which
-          # would sit between the prefix and the input, breaking the
-          # .usa-input-prefix + input CSS adjacency selector that supplies the
-          # input's padding-left. Strip the wrapper only here; Strata renders its
-          # own error markers (usa-input--error, usa-form-group--error, the
-          # usa-error-message span) so nothing visual is lost.
-          if has_error?(attribute)
-            input_el = input_el.to_s.sub(%r{\A<div class="field_with_errors">(.*)</div>\z}m, '\1').html_safe
-          end
           group_class = us_input_group_class(error: has_error?(attribute), width: options[:width])
           input_el = @template.content_tag(:div, class: group_class) do
             @template.safe_join([

--- a/docs/decisions/field-error-proc-override.md
+++ b/docs/decisions/field-error-proc-override.md
@@ -1,0 +1,86 @@
+# ADR-002: Disable Rails `field_with_errors` wrapper engine-wide
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-19
+
+## Context
+
+When an attribute on a form object has validation errors, Rails wraps the
+rendered input in a `<div class="field_with_errors">`. The wrapper is
+injected by `ActionView::Base.field_error_proc`, a class-level lambda that
+runs around every form helper output for an errored attribute.
+
+Strata's form builders already supply their own USWDS error markup
+(`usa-input--error`, `usa-form-group--error`, `usa-error-message`) on every
+helper, so the Rails wrapper duplicates the error signal. Worse, it actively
+breaks USWDS components that rely on adjacent-sibling or direct-child CSS
+selectors. For example, `.usa-input-prefix + input` supplies the input's
+`padding-left`, and a wrapper between the prefix and the input breaks that
+adjacency. The same shape of bug applies to character counters, date
+pickers, combo boxes, and any future USWDS component using selectors like
+these.
+
+PR #337 worked around the prefix/suffix case with a scoped regex strip in
+`Strata::FormBuilder#text_field`, but that fix doesn't generalize — it
+would need to be re-applied by hand in every helper.
+
+## Decision
+
+Set `ActionView::Base.field_error_proc` to a pass-through at the engine
+level, and remove the scoped regex strip from `Strata::FormBuilder#text_field`.
+
+The override lives in [lib/strata/engine.rb](../../lib/strata/engine.rb) as a
+new `strata.field_error_proc` initializer that uses
+`ActiveSupport.on_load(:action_view)` to defer until ActionView is loaded:
+
+```ruby
+initializer "strata.field_error_proc" do
+  ActiveSupport.on_load(:action_view) do
+    ActionView::Base.field_error_proc = ->(html_tag, _instance) { html_tag }
+  end
+end
+```
+
+This makes the `field_with_errors` wrapper disappear from every Strata-rendered
+form, errored or not.
+
+## Consequences
+
+- The `field_with_errors` div is removed for *every* form helper output in
+  applications that mount the Strata engine — not just the helpers Strata
+  itself defines. Strata-rendered forms already convey error state through
+  USWDS-aligned classes; any CSS hooking onto `.field_with_errors` was
+  working around Rails' default rather than expressing intent.
+- The scoped regex strip in `text_field` is removed, simplifying the helper
+  and eliminating a piece of code whose existence was non-obvious unless you
+  knew the prefix-adjacency story.
+- Hosts that explicitly want the wrapper back can restore it from their own
+  initializer (`ActionView::Base.field_error_proc = ActionView::Base::DEFAULT_FIELD_ERROR_PROC`);
+  Strata's runs first, so the host's assignment wins.
+
+## Alternatives considered
+
+### Keep the scoped regex strip
+
+Patch individual helpers as new adjacent-sibling components are added.
+This choice scales linearly with the number of components, leaves the wrapper
+in place everywhere else, and depends on Rails' internal wrapper format not
+changing.
+
+### Gate the override behind a `Strata.config` flag
+
+Add a Strata setting like `Strata.config.disable_field_error_wrapper = true`.
+Hosts have full control via the Rails escape hatch above; a Strata flag
+would be an alternate spelling of the same lever.
+
+### Override only inside Strata form builders
+
+Wrap `field_error_proc` in a per-render block that's only active while a
+`Strata::FormBuilder` is rendering. More code and state for no practical 
+benefit — applications using Strata form builders get the same effective
+behavior from the engine-wide override.

--- a/lib/strata/engine.rb
+++ b/lib/strata/engine.rb
@@ -37,6 +37,24 @@ module Strata
       end
     end
 
+    initializer "strata.field_error_proc" do
+      ActiveSupport.on_load(:action_view) do
+        # Strata renders its own error markup (usa-input--error,
+        # usa-form-group--error, usa-error-message) for every form helper, so
+        # Rails' default field_with_errors wrapper is redundant on top of that
+        # and breaks USWDS adjacent-sibling selectors (e.g. .usa-input-prefix
+        # + input, input + .usa-input-suffix). Override at the engine level so
+        # the wrapper never appears in Strata-rendered forms.
+        #
+        # A host that explicitly wants the wrapper back can set
+        # ActionView::Base.field_error_proc = ActionView::Base::DEFAULT_FIELD_ERROR_PROC
+        # in their own initializer after Strata's runs.
+        #
+        # See docs/decisions/field-error-proc-override.md (ADR-002).
+        ActionView::Base.field_error_proc = ->(html_tag, _instance) { html_tag }
+      end
+    end
+
     initializer "strata.importmap", before: "importmap" do |app|
       if app.config.respond_to?(:importmap)
         app.config.importmap.paths << Engine.root.join("config/importmap.rb")

--- a/spec/helpers/strata/form_builder_spec.rb
+++ b/spec/helpers/strata/form_builder_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Strata::FormBuilder do
       attribute :has_employer, :string
       attribute :leave_type, :string
       attribute :income, :string    # for prefix/suffix tests
+      attribute :agree_to_terms, :boolean  # for check_box error tests
+      attribute :nice_choice, :string      # for radio_button error tests
     end
 
     stub_const("TestForm", test_form_class)
@@ -76,6 +78,14 @@ RSpec.describe Strata::FormBuilder do
       it 'outputs an error message' do
         expect(result).to have_element(:div, class: 'usa-form-group--error')
         expect(result).to have_element(:span, text: 'is invalid', class: 'usa-error-message')
+      end
+
+      it 'does not wrap the input in field_with_errors' do
+        expect(result).not_to have_css('.field_with_errors')
+      end
+
+      it 'still marks the input itself with usa-input--error' do
+        expect(result).to have_element(:input, class: 'usa-input usa-input--error')
       end
     end
 
@@ -193,14 +203,6 @@ RSpec.describe Strata::FormBuilder do
 
       it 'adds the error modifier to the input-group, not just the input' do
         expect(result).to have_element(:div, class: 'usa-input-group usa-input-group--error')
-      end
-
-      it 'keeps the input as the immediate sibling of the prefix in error states' do
-        # USWDS uses .usa-input-prefix + input (adjacent-sibling selector) to apply
-        # padding-left so the input value doesn't sit on top of the prefix. Anything
-        # that lands between them (e.g. Rails' default field_with_errors wrap) would
-        # break that adjacency.
-        expect(result).to have_css('.usa-input-prefix + input')
       end
     end
 
@@ -331,6 +333,10 @@ RSpec.describe Strata::FormBuilder do
         expect(result).to have_element(:select, class: 'usa-select usa-input--error')
         expect(result).to have_element(:span, text: 'is invalid', class: 'usa-error-message')
       end
+
+      it 'does not wrap the select in field_with_errors' do
+        expect(result).not_to have_css('.field_with_errors')
+      end
     end
   end
 
@@ -363,6 +369,18 @@ RSpec.describe Strata::FormBuilder do
 
       it 'outputs a hint' do
         expect(result).to have_element(:span, text: 'Check this box', class: 'usa-checkbox__label-description')
+      end
+    end
+
+    context 'with an error' do
+      let(:result) { builder.check_box(:agree_to_terms) }
+
+      before do
+        object.errors.add(:agree_to_terms, 'is invalid')
+      end
+
+      it 'does not wrap the checkbox in field_with_errors' do
+        expect(result).not_to have_css('.field_with_errors')
       end
     end
 
@@ -401,6 +419,18 @@ RSpec.describe Strata::FormBuilder do
       it 'outputs a radio button without the tile class' do
         expect(result).to have_element(:input, type: 'radio', class: 'usa-radio__input')
         expect(result).not_to have_element(:input, type: 'radio', class: 'usa-radio__input--tile')
+      end
+    end
+
+    context 'with an error' do
+      let(:result) { builder.radio_button(:nice_choice, 'yes') }
+
+      before do
+        object.errors.add(:nice_choice, 'is invalid')
+      end
+
+      it 'does not wrap the radio button in field_with_errors' do
+        expect(result).not_to have_css('.field_with_errors')
       end
     end
   end


### PR DESCRIPTION
## Summary

- Sets `ActionView::Base.field_error_proc` to a pass-through in a new `strata.field_error_proc` initializer in `lib/strata/engine.rb`, so Rails' default `<div class="field_with_errors">` wrapper never appears in Strata-rendered forms.
- Removes the scoped regex strip from `Strata::FormBuilder#text_field` that PR #337 added as a stopgap for the prefix/suffix case — the engine-wide override covers it generally now.
- Adds RSpec coverage on the four primitive form helpers (text_field, select, check_box, radio_button); composites inherit transitively.
- Adds [ADR-002](docs/decisions/field-error-proc-override.md) capturing the rationale, alternatives considered, and the escape hatch for hosts that want the Rails default back.

## Why

USWDS components rely on adjacent-sibling and direct-child CSS selectors (e.g. `.usa-input-prefix + input`). Rails' wrapper sits between those elements and breaks the adjacency. Strata renders its own USWDS error markup (`usa-input--error`, `usa-form-group--error`, `usa-error-message`) so the Rails wrapper adds nothing useful on top of it. Fixing at the engine boundary preempts the bug class for future USWDS components (character counters, date pickers, combo boxes, etc.) instead of patching helpers one at a time.

## Testing

- `make lint` — clean.
- `make test` — 1304 examples, 0 failures.

Closes #339.