### PR TITLE
Add branch naming convention to claude sandbox instructions

### DIFF
--- a/.github/claude-sandbox-instructions.md
+++ b/.github/claude-sandbox-instructions.md
@@ -18,7 +18,7 @@ You can confirm you're in this context by checking that `$GITHUB_ACTIONS == "tru
    - Issue trigger → branch off the default branch
    - PR/review trigger → branch off the PR's head branch
 
-   Use a descriptive name like `claude/<short-description>`. Never push directly to `main`.
+   Name the branch `claude/issue-<number>-<short-description>-<YYYYMMDD>-<HHMM>` (or `claude/pr-<number>-...` when triggered from a PR). The `<short-description>` is a 2–5 word kebab-case summary of the issue/PR — e.g. `claude/issue-254-fix-audit-log-pagination-20260519-2004`. Never push directly to `main`.
 
 3. **Implement.** Follow every rule in [CLAUDE.md](../CLAUDE.md).
 

--- a/.github/claude-sandbox-instructions.md
+++ b/.github/claude-sandbox-instructions.md
@@ -18,7 +18,7 @@ You can confirm you're in this context by checking that `$GITHUB_ACTIONS == "tru
    - Issue trigger → branch off the default branch
    - PR/review trigger → branch off the PR's head branch
 
-   Name the branch `claude/issue-<number>-<short-description>-<YYYYMMDD>-<HHMM>` (or `claude/pr-<number>-...` when triggered from a PR). The `<short-description>` is a 2–5 word kebab-case summary of the issue/PR — e.g. `claude/issue-254-fix-audit-log-pagination-20260519-2004`. Never push directly to `main`.
+   Name the branch `claude/issue-<number>-<short-description>-<YYYYMMDD>-<HHMM>` when triggered from an issue, or `claude/pr-<number>-<short-description>-<YYYYMMDD>-<HHMM>` when triggered from a PR. The `<short-description>` is a 2–5 word kebab-case summary of the issue/PR — e.g. `claude/issue-254-fix-audit-log-pagination-20260519-2004`. Never push directly to `main`.
 
 3. **Implement.** Follow every rule in [CLAUDE.md](../CLAUDE.md).
 


### PR DESCRIPTION
## Summary
- Replace the generic `claude/<short-description>` guidance in [.github/claude-sandbox-instructions.md](.github/claude-sandbox-instructions.md) with a structured format: `claude/issue-<number>-<short-description>-<YYYYMMDD>-<HHMM>` (and a `pr-` variant for PR triggers), so auto-generated branch names include a human-readable summary of the issue/PR alongside the existing number + timestamp.

## Test plan
- [ ] Review the rendered markdown in [.github/claude-sandbox-instructions.md](.github/claude-sandbox-instructions.md) on the PR