### PR TITLE
Add a USWDS Step Indicator component

### DIFF
--- a/app/components/strata/us/step_indicator_component.html.erb
+++ b/app/components/strata/us/step_indicator_component.html.erb
@@ -21,13 +21,15 @@
       <%= tag.li(class: segment_classes(step_indicator), "aria-current": ("true" if step_indicator[:current])) do %>
         <span class="usa-step-indicator__segment-label">
           <%= step_indicator[:name] %>
-          <span class="usa-sr-only">
-            <% if step_indicator[:complete] %>
-              completed
-            <% else %>
-              not completed
-            <% end %>
-          </span>
+          <% unless step_indicator[:current] %>
+            <span class="usa-sr-only">
+              <% if step_indicator[:complete] %>
+                completed
+              <% else %>
+                not completed
+              <% end %>
+            </span>
+          <% end %>
         </span>
       <% end %>
     <% end %>

--- a/app/components/strata/us/step_indicator_component.html.erb
+++ b/app/components/strata/us/step_indicator_component.html.erb
@@ -18,7 +18,7 @@
 
   <ol class="usa-step-indicator__segments">
     <% step_indicators.each do |step_indicator| %>
-      <li class="<%= segment_classes(step_indicator) %>">
+      <%= tag.li(class: segment_classes(step_indicator), "aria-current": ("true" if step_indicator[:current])) do %>
         <span class="usa-step-indicator__segment-label">
           <%= step_indicator[:name] %>
           <span class="usa-sr-only">
@@ -29,7 +29,7 @@
             <% end %>
           </span>
         </span>
-      </li>
+      <% end %>
     <% end %>
   </ol>
 

--- a/app/components/strata/us/step_indicator_component.html.erb
+++ b/app/components/strata/us/step_indicator_component.html.erb
@@ -2,9 +2,9 @@
   <div class="<%= header_classes %>">
     <h4 class="usa-step-indicator__heading display-flex flex-align-center">
       <span class="usa-step-indicator__heading-counter">
-        <span class="usa-sr-only">Step</span>
+        <span class="usa-sr-only"><%= t("strata.components.us.step_indicator.step") %></span>
         <span class="usa-step-indicator__current-step"><%= current_step_index + 1 %></span>
-        <span class="usa-step-indicator__total-steps">of <%= total_steps %></span>
+        <span class="usa-step-indicator__total-steps"><%= t("strata.components.us.step_indicator.of") %> <%= total_steps %></span>
       </span>
       <span class="<%= heading_text_classes %>"><%= current_step_name %></span>
     </h4>
@@ -24,9 +24,9 @@
           <% unless step_indicator[:current] %>
             <span class="usa-sr-only">
               <% if step_indicator[:complete] %>
-                completed
+                <%= t("strata.components.us.step_indicator.completed") %>
               <% else %>
-                not completed
+                <%= t("strata.components.us.step_indicator.not_completed") %>
               <% end %>
             </span>
           <% end %>

--- a/app/components/strata/us/step_indicator_component.html.erb
+++ b/app/components/strata/us/step_indicator_component.html.erb
@@ -1,0 +1,39 @@
+<% header_content = capture do %>
+  <div class="<%= header_classes %>">
+    <h4 class="usa-step-indicator__heading display-flex flex-align-center">
+      <span class="usa-step-indicator__heading-counter">
+        <span class="usa-sr-only">Step</span>
+        <span class="usa-step-indicator__current-step"><%= current_step_index + 1 %></span>
+        <span class="usa-step-indicator__total-steps">of <%= total_steps %></span>
+      </span>
+      <span class="<%= heading_text_classes %>"><%= current_step_name %></span>
+    </h4>
+  </div>
+<% end %>
+
+<div class="<%= wrapper_classes %>" <%= tag.attributes(root_html_attributes) %>>
+  <% if header_first? %>
+    <%= header_content %>
+  <% end %>
+
+  <ol class="usa-step-indicator__segments">
+    <% step_indicators.each do |step_indicator| %>
+      <li class="<%= segment_classes(step_indicator) %>">
+        <span class="usa-step-indicator__segment-label">
+          <%= step_indicator[:name] %>
+          <span class="usa-sr-only">
+            <% if step_indicator[:complete] %>
+              completed
+            <% else %>
+              not completed
+            <% end %>
+          </span>
+        </span>
+      </li>
+    <% end %>
+  </ol>
+
+  <% unless header_first? %>
+    <%= header_content %>
+  <% end %>
+</div>

--- a/app/components/strata/us/step_indicator_component.rb
+++ b/app/components/strata/us/step_indicator_component.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Strata
+  module US
+    # StepIndicatorComponent renders a USWDS step indicator that shows progress
+    # through a multi-step process. See https://designsystem.digital.gov/components/step-indicator/.
+    #
+    # Each step's display name is looked up under `translation_scope` and falls
+    # back to a humanized form of the step symbol when no translation exists.
+    # Steps before and including `current_step` are marked complete; the
+    # `current_step` is additionally marked current.
+    #
+    # @example Basic usage
+    #   <%= render Strata::US::StepIndicatorComponent.new(
+    #         steps: [:personal_info, :review, :submit],
+    #         current_step: :review
+    #       ) %>
+    #
+    # @example Counters variant with the header above the segments
+    #   <%= render Strata::US::StepIndicatorComponent.new(
+    #         steps: [:in_progress, :submitted, :decision_made],
+    #         current_step: :submitted,
+    #         type: :counters,
+    #         large_header: true,
+    #         header_first: true
+    #       ) %>
+    class StepIndicatorComponent < ViewComponent::Base
+      def initialize(
+        steps:,
+        current_step:,
+        translation_scope: "strata.application_forms.steps",
+        large_header: false,
+        header_first: false,
+        type: nil,
+        classes: nil,
+        **html_attributes
+      )
+        @steps = Array(steps).map(&:to_sym)
+        @current_step = current_step.to_sym
+        @translation_scope = translation_scope
+        @large_header = large_header
+        @header_first = header_first
+        @type = type
+        @classes = classes
+        @html_attributes = html_attributes
+      end
+
+      def step_indicators
+        @step_indicators ||= @steps.map.with_index do |step, index|
+          {
+            name: t(step.to_s, scope: @translation_scope, default: step.to_s.humanize),
+            complete: index <= current_step_index,
+            current: step == @current_step
+          }
+        end
+      end
+
+      def current_step_index
+        @current_step_index ||= @steps.index(@current_step) || -1
+      end
+
+      def current_step_name
+        step_indicators[current_step_index]&.dig(:name) || @current_step.to_s.humanize
+      end
+
+      def total_steps
+        @steps.length
+      end
+
+      def header_first?
+        @header_first
+      end
+
+      def wrapper_classes
+        class_names(
+          "usa-step-indicator",
+          { "usa-step-indicator--counters" => @type == :counters },
+          @classes
+        )
+      end
+
+      def header_classes
+        class_names("usa-step-indicator__header", "margin-bottom-2": @header_first)
+      end
+
+      def heading_text_classes
+        class_names("usa-step-indicator__heading-text", "font-heading-xl": @large_header)
+      end
+
+      def segment_classes(step_indicator)
+        class_names(
+          "usa-step-indicator__segment",
+          "usa-step-indicator__segment--complete": step_indicator[:complete],
+          "usa-step-indicator__segment--current": step_indicator[:current]
+        )
+      end
+
+      def root_html_attributes
+        attrs = @html_attributes.dup
+        attrs.delete(:class)
+        attrs[:"aria-label"] = "progress"
+        attrs
+      end
+    end
+  end
+end

--- a/app/components/strata/us/step_indicator_component.rb
+++ b/app/components/strata/us/step_indicator_component.rb
@@ -114,7 +114,6 @@ module Strata
       def root_html_attributes
         attrs = @html_attributes.dup
         attrs.delete(:class)
-        attrs[:"aria-label"] = t("strata.components.us.step_indicator.aria_label")
         attrs
       end
     end

--- a/app/components/strata/us/step_indicator_component.rb
+++ b/app/components/strata/us/step_indicator_component.rb
@@ -24,8 +24,18 @@ module Strata
     #         large_header: true,
     #         header_first: true
     #       ) %>
+    #
+    # The `type` option also accepts `:counters_sm`, `:center`, and `:no_labels`,
+    # each of which maps to the corresponding `usa-step-indicator--*` modifier.
     class StepIndicatorComponent < ViewComponent::Base
       DEFAULT_TRANSLATION_SCOPE = "strata.application_forms.steps"
+
+      TYPE_CLASSES = {
+        counters: "usa-step-indicator--counters",
+        counters_sm: "usa-step-indicator--counters-sm",
+        center: "usa-step-indicator--center",
+        no_labels: "usa-step-indicator--no-labels"
+      }.freeze
 
       def initialize(
         steps:,
@@ -80,7 +90,7 @@ module Strata
       def wrapper_classes
         class_names(
           "usa-step-indicator",
-          { "usa-step-indicator--counters" => @type == :counters },
+          TYPE_CLASSES[@type],
           @classes
         )
       end

--- a/app/components/strata/us/step_indicator_component.rb
+++ b/app/components/strata/us/step_indicator_component.rb
@@ -114,7 +114,7 @@ module Strata
       def root_html_attributes
         attrs = @html_attributes.dup
         attrs.delete(:class)
-        attrs[:"aria-label"] = "progress"
+        attrs[:"aria-label"] = t("strata.components.us.step_indicator.aria_label")
         attrs
       end
     end

--- a/app/components/strata/us/step_indicator_component.rb
+++ b/app/components/strata/us/step_indicator_component.rb
@@ -7,8 +7,8 @@ module Strata
     #
     # Each step's display name is looked up under `translation_scope` and falls
     # back to a humanized form of the step symbol when no translation exists.
-    # Steps before and including `current_step` are marked complete; the
-    # `current_step` is additionally marked current.
+    # Steps before `current_step` are marked complete; the `current_step` is
+    # marked current.
     #
     # @example Basic usage
     #   <%= render Strata::US::StepIndicatorComponent.new(
@@ -65,7 +65,7 @@ module Strata
         @step_indicators ||= @steps.map.with_index do |step, index|
           {
             name: t(step.to_s, scope: @translation_scope, default: step.to_s.humanize),
-            complete: index <= current_step_index,
+            complete: index < current_step_index,
             current: step == @current_step
           }
         end

--- a/app/components/strata/us/step_indicator_component.rb
+++ b/app/components/strata/us/step_indicator_component.rb
@@ -39,6 +39,10 @@ module Strata
       )
         @steps = Array(steps).map(&:to_sym)
         @current_step = current_step.to_sym
+        unless @steps.include?(@current_step)
+          raise ArgumentError,
+                "Invalid current_step: #{@current_step.inspect}. Must be one of #{@steps.inspect}"
+        end
         @translation_scope = translation_scope || DEFAULT_TRANSLATION_SCOPE
         @large_header = large_header
         @header_first = header_first
@@ -58,11 +62,11 @@ module Strata
       end
 
       def current_step_index
-        @current_step_index ||= @steps.index(@current_step) || -1
+        @current_step_index ||= @steps.index(@current_step)
       end
 
       def current_step_name
-        step_indicators[current_step_index]&.dig(:name) || @current_step.to_s.humanize
+        step_indicators[current_step_index][:name]
       end
 
       def total_steps

--- a/app/components/strata/us/step_indicator_component.rb
+++ b/app/components/strata/us/step_indicator_component.rb
@@ -25,10 +25,12 @@ module Strata
     #         header_first: true
     #       ) %>
     class StepIndicatorComponent < ViewComponent::Base
+      DEFAULT_TRANSLATION_SCOPE = "strata.application_forms.steps"
+
       def initialize(
         steps:,
         current_step:,
-        translation_scope: "strata.application_forms.steps",
+        translation_scope: DEFAULT_TRANSLATION_SCOPE,
         large_header: false,
         header_first: false,
         type: nil,
@@ -37,7 +39,7 @@ module Strata
       )
         @steps = Array(steps).map(&:to_sym)
         @current_step = current_step.to_sym
-        @translation_scope = translation_scope
+        @translation_scope = translation_scope || DEFAULT_TRANSLATION_SCOPE
         @large_header = large_header
         @header_first = header_first
         @type = type

--- a/app/components/strata/us/step_indicator_component.rb
+++ b/app/components/strata/us/step_indicator_component.rb
@@ -40,7 +40,7 @@ module Strata
       def initialize(
         steps:,
         current_step:,
-        translation_scope: DEFAULT_TRANSLATION_SCOPE,
+        translation_scope: nil,
         large_header: false,
         header_first: false,
         type: nil,

--- a/app/previews/strata/us/step_indicator_component_preview.rb
+++ b/app/previews/strata/us/step_indicator_component_preview.rb
@@ -1,71 +1,70 @@
 # frozen_string_literal: true
 
 module Strata
-  module Shared
-    # StepIndicatorPreview provides preview examples for the step indicator component.
-    # It demonstrates different states of the step indicator including in-progress,
-    # submitted, and decision-made states.
+  module US
+    # StepIndicatorComponentPreview provides preview examples for
+    # Strata::US::StepIndicatorComponent. It demonstrates the default and
+    # counters variants and the three application_form statuses (in-progress,
+    # submitted, decision-made), plus the large-header / header-first layout.
     #
-    # This class is used with Lookbook to generate UI component previews
-    # for the step indicator component used in multi-step forms.
+    # This class is used with Lookbook to generate UI component previews.
     #
     # @example Viewing the submitted state preview
     #   # In Lookbook UI
-    #   # Navigate to Strata > StepIndicatorPreview > submitted
-    #
-    class StepIndicatorPreview < Lookbook::Preview
+    #   # Navigate to Strata > US > StepIndicatorComponent > submitted
+    class StepIndicatorComponentPreview < Lookbook::Preview
       layout "strata/component_preview"
 
       def default
-        render template: "strata/shared/_step_indicator", locals: {
+        render Strata::US::StepIndicatorComponent.new(
           steps: [ :in_progress, :submitted, :decision_made ],
           current_step: :submitted
-        }
+        )
       end
 
       def counters
-        render template: "strata/shared/_step_indicator", locals: {
+        render Strata::US::StepIndicatorComponent.new(
           type: :counters,
           steps: [ :in_progress, :submitted, :decision_made ],
           current_step: :submitted
-        }
+        )
       end
 
       # @!group Statuses
 
       def in_progress
-        render template: "strata/shared/_step_indicator", locals: {
+        render Strata::US::StepIndicatorComponent.new(
           type: :counters,
           steps: [ :in_progress, :submitted, :decision_made ],
           current_step: :in_progress
-        }
+        )
       end
 
       def submitted
-        render template: "strata/shared/_step_indicator", locals: {
+        render Strata::US::StepIndicatorComponent.new(
           type: :counters,
           steps: [ :in_progress, :submitted, :decision_made ],
           current_step: :submitted
-        }
+        )
       end
 
       def decision_made
-        render template: "strata/shared/_step_indicator", locals: {
+        render Strata::US::StepIndicatorComponent.new(
           type: :counters,
           steps: [ :in_progress, :submitted, :decision_made ],
           current_step: :decision_made
-        }
+        )
       end
 
       # @!endgroup
 
       def large_header_first
-        render template: "strata/shared/_step_indicator", locals: {
+        render Strata::US::StepIndicatorComponent.new(
           steps: [ :in_progress, :submitted, :decision_made ],
           current_step: :submitted,
           large_header: true,
           header_first: true
-        }
+        )
       end
     end
   end

--- a/app/previews/strata/us/step_indicator_component_preview.rb
+++ b/app/previews/strata/us/step_indicator_component_preview.rb
@@ -30,6 +30,30 @@ module Strata
         )
       end
 
+      def counters_sm
+        render Strata::US::StepIndicatorComponent.new(
+          type: :counters_sm,
+          steps: [ :in_progress, :submitted, :decision_made ],
+          current_step: :submitted
+        )
+      end
+
+      def center
+        render Strata::US::StepIndicatorComponent.new(
+          type: :center,
+          steps: [ :in_progress, :submitted, :decision_made ],
+          current_step: :submitted
+        )
+      end
+
+      def no_labels
+        render Strata::US::StepIndicatorComponent.new(
+          type: :no_labels,
+          steps: [ :in_progress, :submitted, :decision_made ],
+          current_step: :submitted
+        )
+      end
+
       # @!group Statuses
 
       def in_progress

--- a/app/views/strata/application_forms/show.html.erb
+++ b/app/views/strata/application_forms/show.html.erb
@@ -27,11 +27,11 @@
 
 <h1><%= title %></h1>
 
-<%= render partial: "strata/shared/step_indicator", locals: {
+<%= render Strata::US::StepIndicatorComponent.new(
   type: :counters,
   steps: [:in_progress, :submitted, :decision_made],
   current_step: current_status
-} %>
+) %>
 
 <p class="usa-intro">
   <%= next_step %>

--- a/app/views/strata/shared/_step_indicator.html.erb
+++ b/app/views/strata/shared/_step_indicator.html.erb
@@ -1,13 +1,5 @@
-<%#
-  DEPRECATED: Prefer rendering Strata::US::StepIndicatorComponent directly.
-
-    <%= render Strata::US::StepIndicatorComponent.new(
-          steps: ..., current_step: ..., type: :counters, large_header: true, header_first: true
-        ) %>
-
-  This partial is preserved so existing host apps and generated layouts that
-  call `render partial: "strata/shared/step_indicator"` continue to work.
-%>
+<%# DEPRECATED: prefer rendering Strata::US::StepIndicatorComponent directly. %>
+<%# Preserved so existing callers using `render partial: "strata/shared/step_indicator"` keep working. %>
 <%= render Strata::US::StepIndicatorComponent.new(
       steps: steps,
       current_step: current_step,

--- a/app/views/strata/shared/_step_indicator.html.erb
+++ b/app/views/strata/shared/_step_indicator.html.erb
@@ -1,80 +1,18 @@
-<%
-# Renders a step indicator that shows progress through a multi-step process.
-#
-# @param steps [Array<String, Symbol>] An array of step identifiers that will be displayed in order
-# @param current_step [String, Symbol] The identifier of the current active step
-# @param translation_scope [String] - I18n scope prefix, defaulting to 'strata.application_forms.steps'
-# @param large_header [Boolean] (optional) - Adds "font-heading-xl" class to the heading text
-# @param header_first [Boolean] (optional) - Shows the header above the segments with "margin-bottom-2" class
-#
-# Each step's display name is fetched from the i18n translations under strata.application_forms.steps
-# Steps before and including the current step are marked as complete.
+<%#
+  DEPRECATED: Prefer rendering Strata::US::StepIndicatorComponent directly.
 
-steps = steps.map(&:to_sym)
-current_step = current_step.to_sym
-current_step_index = steps.index(current_step) || -1
-translation_scope ||= "strata.application_forms.steps"
-large_header ||= false
-header_first ||= false
+    <%= render Strata::US::StepIndicatorComponent.new(
+          steps: ..., current_step: ..., type: :counters, large_header: true, header_first: true
+        ) %>
 
-step_indicators = steps.map.with_index do |step, index|
-  {
-    name: t("#{ step }", scope: translation_scope, default: step.to_s.humanize),
-    complete: index <= current_step_index,
-    current: step == current_step
-  }
-end
-
-current_step_name = step_indicators[current_step_index]&.dig(:name) || current_step.to_s.humanize
-step_indicator_class = ""
-step_indicator_class += "usa-step-indicator--counters" if local_assigns[:type] == :counters
+  This partial is preserved so existing host apps and generated layouts that
+  call `render partial: "strata/shared/step_indicator"` continue to work.
 %>
-
-<% header_content = capture do %>
-  <div class="<%= class_names("usa-step-indicator__header", "margin-bottom-2": header_first) %>">
-    <h4 class="usa-step-indicator__heading display-flex flex-align-center">
-      <span class="usa-step-indicator__heading-counter">
-        <span class="usa-sr-only">Step</span>
-        <span class="usa-step-indicator__current-step"><%= current_step_index + 1 %></span>
-        <span class="usa-step-indicator__total-steps">of <%= steps.length %></span>
-      </span>
-      <span class="<%= class_names("usa-step-indicator__heading-text", "font-heading-xl": large_header) %>"><%= current_step_name %></span>
-    </h4>
-  </div>
-<% end %>
-
-<div
-  class="usa-step-indicator <%= step_indicator_class %>"
-  aria-label="progress"
->
-  <% if header_first %>
-    <%= header_content %>
-  <% end %>
-
-  <ol class="usa-step-indicator__segments">
-    <% step_indicators.each do |step_indicator| %>
-      <li
-        class="<%= class_names(
-          "usa-step-indicator__segment",
-          "usa-step-indicator__segment--complete": step_indicator[:complete],
-          "usa-step-indicator__segment--current": step_indicator[:current]
-        )%>"
-      >
-          <span class="usa-step-indicator__segment-label">
-            <%= step_indicator[:name] %>
-            <span class="usa-sr-only">
-              <% if step_indicator[:complete] %>
-                completed
-              <% else %>
-                not completed
-              <% end %>
-            </span>
-          </span>
-        </li>
-    <% end %>
-  </ol>
-
-  <% unless header_first %>
-    <%= header_content %>
-  <% end %>
-</div>
+<%= render Strata::US::StepIndicatorComponent.new(
+      steps: steps,
+      current_step: current_step,
+      translation_scope: local_assigns.fetch(:translation_scope, "strata.application_forms.steps"),
+      large_header: local_assigns.fetch(:large_header, false),
+      header_first: local_assigns.fetch(:header_first, false),
+      type: local_assigns[:type]
+    ) %>

--- a/app/views/strata/shared/_step_indicator.html.erb
+++ b/app/views/strata/shared/_step_indicator.html.erb
@@ -1,10 +1,5 @@
 <%# DEPRECATED: prefer rendering Strata::US::StepIndicatorComponent directly. %>
 <%# Preserved so existing callers using `render partial: "strata/shared/step_indicator"` keep working. %>
 <%= render Strata::US::StepIndicatorComponent.new(
-      steps: steps,
-      current_step: current_step,
-      translation_scope: local_assigns.fetch(:translation_scope, "strata.application_forms.steps"),
-      large_header: local_assigns.fetch(:large_header, false),
-      header_first: local_assigns.fetch(:header_first, false),
-      type: local_assigns[:type]
+      **local_assigns.slice(:steps, :current_step, :translation_scope, :large_header, :header_first, :type)
     ) %>

--- a/config/locales/strata/en.yml
+++ b/config/locales/strata/en.yml
@@ -18,6 +18,12 @@ en:
       us:
         breadcrumbs:
           aria_label: "Breadcrumb"
+        step_indicator:
+          aria_label: "progress"
+          step: "Step"
+          of: "of"
+          completed: "completed"
+          not_completed: "not completed"
     application_forms:
       index:
         col_created_at: "Created At"

--- a/config/locales/strata/en.yml
+++ b/config/locales/strata/en.yml
@@ -19,7 +19,6 @@ en:
         breadcrumbs:
           aria_label: "Breadcrumb"
         step_indicator:
-          aria_label: "progress"
           step: "Step"
           of: "of"
           completed: "completed"

--- a/config/locales/strata/es-US.yml
+++ b/config/locales/strata/es-US.yml
@@ -15,6 +15,12 @@ es-US:
       us:
         breadcrumbs:
           aria_label: "Ruta de navegación"
+        step_indicator:
+          aria_label: "progreso"
+          step: "Paso"
+          of: "de"
+          completed: "completado"
+          not_completed: "no completado"
     application_forms:
       index:
         col_created_at: "Fecha de creación"

--- a/config/locales/strata/es-US.yml
+++ b/config/locales/strata/es-US.yml
@@ -16,7 +16,6 @@ es-US:
         breadcrumbs:
           aria_label: "Ruta de navegación"
         step_indicator:
-          aria_label: "progreso"
           step: "Paso"
           of: "de"
           completed: "completado"

--- a/docs/uswds-components.md
+++ b/docs/uswds-components.md
@@ -228,7 +228,7 @@ At least one of header, media, body, or footer must be provided.
 
 `Strata::US::StepIndicatorComponent` — progress display for a multi-step process. See [USWDS Step Indicator](https://designsystem.digital.gov/components/step-indicator/) and the [Lookbook preview](../app/previews/strata/us/step_indicator_component_preview.rb).
 
-Steps before and including `current_step` are marked complete; the `current_step` is additionally marked current. Each step's display name is looked up under `translation_scope` and falls back to a humanized form of the step symbol when no translation exists.
+Steps before `current_step` are marked complete; `current_step` is marked current (with `aria-current="true"`). Each step's display name is looked up under `translation_scope` and falls back to a humanized form of the step symbol when no translation exists.
 
 **Options**
 
@@ -237,10 +237,14 @@ Steps before and including `current_step` are marked complete; the `current_step
 - `translation_scope:` — I18n scope used to look up each step's display name. Defaults to `"strata.application_forms.steps"`.
 - `large_header:` — adds `font-heading-xl` to the heading text. Defaults to `false`.
 - `header_first:` — render the header above the segments (with `margin-bottom-2`) instead of below. Defaults to `false`.
-- `type:` — set to `:counters` for the counters variant (numbered segments).
+- `type:` — selects a USWDS variant. One of:
+    - `:counters` → `usa-step-indicator--counters` (numbered segments)
+    - `:counters_sm` → `usa-step-indicator--counters-sm` (small numbered segments)
+    - `:center` → `usa-step-indicator--center` (centered labels)
+    - `:no_labels` → `usa-step-indicator--no-labels` (hides segment labels)
 - `classes:` — extra CSS classes appended to the root `<div>`.
 
-Any other keyword arguments are forwarded as HTML attributes on the root `<div>` (`aria-label="progress"` is set by the component).
+Any other keyword arguments are forwarded as HTML attributes on the root `<div>`. The component does not set `aria-label` itself; if you want one, pass `aria: { label: "…" }` (or `aria_label:` depending on call style).
 
 **Example**
 

--- a/docs/uswds-components.md
+++ b/docs/uswds-components.md
@@ -20,7 +20,8 @@ Every component accepts a `classes:` keyword for additional CSS classes and forw
 4. [Card](#card)
 5. [Card Group](#card-group)
 6. [List](#list)
-7. [Table](#table)
+7. [Step Indicator](#step-indicator)
+8. [Table](#table)
 
 ---
 
@@ -219,6 +220,43 @@ At least one of header, media, body, or footer must be provided.
 <%= render Strata::US::ListComponent.new(ordered: true) do |list| %>
   <% list.with_items(["Apples", "Bananas", "Cherries"]) %>
 <% end %>
+```
+
+---
+
+## Step Indicator
+
+`Strata::US::StepIndicatorComponent` — progress display for a multi-step process. See [USWDS Step Indicator](https://designsystem.digital.gov/components/step-indicator/) and the [Lookbook preview](../app/previews/strata/us/step_indicator_component_preview.rb).
+
+Steps before and including `current_step` are marked complete; the `current_step` is additionally marked current. Each step's display name is looked up under `translation_scope` and falls back to a humanized form of the step symbol when no translation exists.
+
+**Options**
+
+- `steps:` (required) — array of step identifiers (symbols or strings) rendered in order.
+- `current_step:` (required) — identifier of the active step.
+- `translation_scope:` — I18n scope used to look up each step's display name. Defaults to `"strata.application_forms.steps"`.
+- `large_header:` — adds `font-heading-xl` to the heading text. Defaults to `false`.
+- `header_first:` — render the header above the segments (with `margin-bottom-2`) instead of below. Defaults to `false`.
+- `type:` — set to `:counters` for the counters variant (numbered segments).
+- `classes:` — extra CSS classes appended to the root `<div>`.
+
+Any other keyword arguments are forwarded as HTML attributes on the root `<div>` (`aria-label="progress"` is set by the component).
+
+**Example**
+
+```erb
+<%= render Strata::US::StepIndicatorComponent.new(
+      steps: [:personal_info, :review, :submit],
+      current_step: :review
+    ) %>
+
+<%= render Strata::US::StepIndicatorComponent.new(
+      steps: [:in_progress, :submitted, :decision_made],
+      current_step: :submitted,
+      type: :counters,
+      large_header: true,
+      header_first: true
+    ) %>
 ```
 
 ---

--- a/lib/generators/strata/application_form_views/templates/layout.html.erb.tt
+++ b/lib/generators/strata/application_form_views/templates/layout.html.erb.tt
@@ -4,10 +4,10 @@
     exit_text: t("<%= form_name.underscore.pluralize %>.actions.exit")
   } %>
   <div class="margin-y-2">
-    <%%= render partial: "strata/shared/step_indicator", locals: {
+    <%%= render Strata::US::StepIndicatorComponent.new(
       steps: @flow_task.pages.map(&:name),
       current_step: @flow_task.current_page.name,
-    } %>
+    ) %>
   </div>
   <%%= yield %>
 <%% end %>

--- a/spec/components/strata/us/step_indicator_component_spec.rb
+++ b/spec/components/strata/us/step_indicator_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Strata::US::StepIndicatorComponent, type: :component do
     it "renders a div.usa-step-indicator wrapping the segments list and header" do
       render_default
 
-      expect(page).to have_css("div.usa-step-indicator[aria-label='progress']")
+      expect(page).to have_css("div.usa-step-indicator")
       expect(page).to have_css("div.usa-step-indicator > ol.usa-step-indicator__segments")
       expect(page).to have_css(
         "div.usa-step-indicator > div.usa-step-indicator__header > h4.usa-step-indicator__heading"
@@ -341,13 +341,6 @@ RSpec.describe Strata::US::StepIndicatorComponent, type: :component do
       expect(page).not_to have_css("div.from-html-attrs")
     end
 
-    it "does not override the built-in aria-label='progress' from html_attributes" do
-      # The component owns aria-label='progress' on the root. We intentionally
-      # do not expose it as an option to keep the component focused.
-      render_default
-
-      expect(page).to have_css("div.usa-step-indicator[aria-label='progress']")
-    end
   end
 
   describe "XSS safety" do

--- a/spec/components/strata/us/step_indicator_component_spec.rb
+++ b/spec/components/strata/us/step_indicator_component_spec.rb
@@ -155,6 +155,18 @@ RSpec.describe Strata::US::StepIndicatorComponent, type: :component do
       expect(page).to have_css(".usa-step-indicator__heading-text", text: "Default-scope review")
       expect(page).to have_css(".usa-step-indicator__segment-label", text: "Default-scope review")
     end
+
+    it "coerces an explicit translation_scope: nil to the default scope" do
+      I18n.backend.store_translations(
+        :en,
+        strata: { application_forms: { steps: { review: "Default-scope review" } } }
+      )
+
+      render_default(translation_scope: nil)
+
+      expect(page).to have_css(".usa-step-indicator__heading-text", text: "Default-scope review")
+      expect(page).to have_css(".usa-step-indicator__segment-label", text: "Default-scope review")
+    end
   end
 
   describe "large_header option" do

--- a/spec/components/strata/us/step_indicator_component_spec.rb
+++ b/spec/components/strata/us/step_indicator_component_spec.rb
@@ -114,6 +114,54 @@ RSpec.describe Strata::US::StepIndicatorComponent, type: :component do
     end
   end
 
+  describe "type: :counters_sm variant" do
+    it "adds usa-step-indicator--counters-sm to the root when type: :counters_sm" do
+      render_default(type: :counters_sm)
+
+      expect(page).to have_css("div.usa-step-indicator.usa-step-indicator--counters-sm")
+    end
+
+    it "does not add usa-step-indicator--counters-sm by default" do
+      render_default
+
+      expect(page).not_to have_css(".usa-step-indicator--counters-sm")
+    end
+
+    it "does not add the plain --counters class when type: :counters_sm" do
+      render_default(type: :counters_sm)
+
+      expect(page).not_to have_css(".usa-step-indicator--counters:not(.usa-step-indicator--counters-sm)")
+    end
+  end
+
+  describe "type: :center variant" do
+    it "adds usa-step-indicator--center to the root when type: :center" do
+      render_default(type: :center)
+
+      expect(page).to have_css("div.usa-step-indicator.usa-step-indicator--center")
+    end
+
+    it "does not add usa-step-indicator--center by default" do
+      render_default
+
+      expect(page).not_to have_css(".usa-step-indicator--center")
+    end
+  end
+
+  describe "type: :no_labels variant" do
+    it "adds usa-step-indicator--no-labels to the root when type: :no_labels" do
+      render_default(type: :no_labels)
+
+      expect(page).to have_css("div.usa-step-indicator.usa-step-indicator--no-labels")
+    end
+
+    it "does not add usa-step-indicator--no-labels by default" do
+      render_default
+
+      expect(page).not_to have_css(".usa-step-indicator--no-labels")
+    end
+  end
+
   describe "i18n display names" do
     let(:scope) { "spec.step_indicator_component.steps" }
 

--- a/spec/components/strata/us/step_indicator_component_spec.rb
+++ b/spec/components/strata/us/step_indicator_component_spec.rb
@@ -215,19 +215,41 @@ RSpec.describe Strata::US::StepIndicatorComponent, type: :component do
     end
   end
 
-  describe "unknown current_step (defensive)" do
-    it "renders without raising and marks no segment as current or complete" do
-      render_inline(described_class.new(steps: steps, current_step: :unknown_step))
-
-      expect(page).not_to have_css("li.usa-step-indicator__segment--current")
-      expect(page).not_to have_css("li.usa-step-indicator__segment--complete")
+  describe "current_step not in steps" do
+    it "raises ArgumentError when current_step is not in steps" do
+      expect {
+        described_class.new(steps: [ :a, :b, :c ], current_step: :unknown)
+      }.to raise_error(
+        ArgumentError,
+        "Invalid current_step: :unknown. Must be one of [:a, :b, :c]"
+      )
     end
 
-    it "falls back to the humanized current_step in the heading when steps is empty" do
-      render_inline(described_class.new(steps: [], current_step: :unknown_step))
+    it "raises ArgumentError when steps is empty" do
+      expect {
+        described_class.new(steps: [], current_step: :anything)
+      }.to raise_error(
+        ArgumentError,
+        "Invalid current_step: :anything. Must be one of []"
+      )
+    end
 
-      expect(page).to have_css(".usa-step-indicator__heading-text", text: "Unknown step")
-      expect(page).not_to have_css("li.usa-step-indicator__segment")
+    it "raises at initialization (before render)" do
+      expect {
+        described_class.new(steps: [ :a, :b ], current_step: :c)
+      }.to raise_error(ArgumentError)
+    end
+
+    it "validates after symbol normalization (string current_step matching symbol steps)" do
+      expect {
+        described_class.new(steps: [ :a, :b ], current_step: "b")
+      }.not_to raise_error
+    end
+
+    it "validates after symbol normalization (symbol current_step matching string steps)" do
+      expect {
+        described_class.new(steps: [ "a", "b" ], current_step: :b)
+      }.not_to raise_error
     end
   end
 

--- a/spec/components/strata/us/step_indicator_component_spec.rb
+++ b/spec/components/strata/us/step_indicator_component_spec.rb
@@ -1,0 +1,275 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Strata::US::StepIndicatorComponent, type: :component do
+  let(:steps) { [ :personal_info, :review, :submit ] }
+  let(:current_step) { :review }
+
+  def render_default(**overrides)
+    args = { steps: steps, current_step: current_step }.merge(overrides)
+    render_inline(described_class.new(**args))
+  end
+
+  describe "structural markup" do
+    it "renders a div.usa-step-indicator wrapping the segments list and header" do
+      render_default
+
+      expect(page).to have_css("div.usa-step-indicator[aria-label='progress']")
+      expect(page).to have_css("div.usa-step-indicator > ol.usa-step-indicator__segments")
+      expect(page).to have_css(
+        "div.usa-step-indicator > div.usa-step-indicator__header > h4.usa-step-indicator__heading"
+      )
+    end
+
+    it "renders one <li> per step" do
+      render_default
+
+      expect(page).to have_css("li.usa-step-indicator__segment", count: steps.length)
+    end
+
+    it "renders the heading counter as 'Step N of M' with current step number" do
+      render_default
+
+      expect(page).to have_css(".usa-step-indicator__heading-counter .usa-sr-only", text: "Step")
+      expect(page).to have_css(".usa-step-indicator__current-step", text: "2")
+      expect(page).to have_css(".usa-step-indicator__total-steps", text: "of 3")
+    end
+  end
+
+  describe "segment state — complete (steps before the current step)" do
+    it "marks them with usa-step-indicator__segment--complete" do
+      render_default
+
+      segments = page.all("li.usa-step-indicator__segment")
+      expect(segments[0][:class]).to include("usa-step-indicator__segment--complete")
+    end
+
+    it "renders 'completed' as screen-reader text" do
+      render_default
+
+      first = page.all("li.usa-step-indicator__segment").first
+      expect(first).to have_css(".usa-sr-only", text: "completed")
+    end
+  end
+
+  describe "segment state — current (the active step)" do
+    it "marks it with both --current and --complete (per existing logic)" do
+      render_default
+
+      current = page.find("li.usa-step-indicator__segment--current")
+      expect(current[:class]).to include("usa-step-indicator__segment--complete")
+    end
+
+    it "marks exactly one segment as --current" do
+      render_default
+
+      expect(page).to have_css("li.usa-step-indicator__segment--current", count: 1)
+    end
+
+    it "shows the current step's display name in the heading text" do
+      render_default
+
+      expect(page).to have_css(
+        ".usa-step-indicator__heading-text",
+        text: "Review"
+      )
+    end
+  end
+
+  describe "segment state — future (steps after the current step)" do
+    it "does not mark them with --complete or --current" do
+      render_default
+
+      last = page.all("li.usa-step-indicator__segment").last
+      expect(last[:class]).not_to include("usa-step-indicator__segment--complete")
+      expect(last[:class]).not_to include("usa-step-indicator__segment--current")
+    end
+
+    it "renders 'not completed' as screen-reader text" do
+      render_default
+
+      last = page.all("li.usa-step-indicator__segment").last
+      expect(last).to have_css(".usa-sr-only", text: "not completed")
+    end
+  end
+
+  describe "type: :counters variant" do
+    it "adds usa-step-indicator--counters to the root when type: :counters" do
+      render_default(type: :counters)
+
+      expect(page).to have_css("div.usa-step-indicator.usa-step-indicator--counters")
+    end
+
+    it "does not add usa-step-indicator--counters by default" do
+      render_default
+
+      expect(page).not_to have_css(".usa-step-indicator--counters")
+    end
+
+    it "ignores unknown type values" do
+      render_default(type: :something_else)
+
+      expect(page).not_to have_css(".usa-step-indicator--counters")
+    end
+  end
+
+  describe "i18n display names" do
+    let(:scope) { "spec.step_indicator_component.steps" }
+
+    around do |example|
+      I18n.backend.store_translations(
+        :en,
+        spec: { step_indicator_component: { steps: { review: "Review your answers" } } }
+      )
+      example.run
+    end
+
+    it "uses the translation under translation_scope for each step's label" do
+      render_default(translation_scope: scope)
+
+      expect(page).to have_css(".usa-step-indicator__segment-label", text: "Review your answers")
+    end
+
+    it "uses the translation in the heading text" do
+      render_default(translation_scope: scope)
+
+      expect(page).to have_css(".usa-step-indicator__heading-text", text: "Review your answers")
+    end
+
+    it "falls back to a humanized symbol when no translation exists for a step" do
+      render_default(translation_scope: scope)
+
+      expect(page).to have_css(".usa-step-indicator__segment-label", text: "Personal info")
+      expect(page).to have_css(".usa-step-indicator__segment-label", text: "Submit")
+    end
+
+    it "defaults translation_scope to strata.application_forms.steps" do
+      I18n.backend.store_translations(
+        :en,
+        strata: { application_forms: { steps: { review: "Default-scope review" } } }
+      )
+
+      render_default
+
+      expect(page).to have_css(".usa-step-indicator__heading-text", text: "Default-scope review")
+      expect(page).to have_css(".usa-step-indicator__segment-label", text: "Default-scope review")
+    end
+  end
+
+  describe "large_header option" do
+    it "adds font-heading-xl to the heading text when true" do
+      render_default(large_header: true)
+
+      expect(page).to have_css(".usa-step-indicator__heading-text.font-heading-xl")
+    end
+
+    it "does not add font-heading-xl by default" do
+      render_default
+
+      expect(page).not_to have_css(".font-heading-xl")
+    end
+  end
+
+  describe "header_first option" do
+    it "renders the header before the segments and adds margin-bottom-2 when true" do
+      render_default(header_first: true)
+
+      expect(page).to have_css(
+        "div.usa-step-indicator > div.usa-step-indicator__header.margin-bottom-2 + ol.usa-step-indicator__segments"
+      )
+    end
+
+    it "renders the header after the segments by default, without margin-bottom-2" do
+      render_default
+
+      expect(page).to have_css(
+        "div.usa-step-indicator > ol.usa-step-indicator__segments + div.usa-step-indicator__header"
+      )
+      expect(page).not_to have_css(".usa-step-indicator__header.margin-bottom-2")
+    end
+  end
+
+  describe "string inputs (steps and current_step)" do
+    it "accepts string values and normalizes them to symbols" do
+      render_inline(described_class.new(
+        steps: [ "personal_info", "review", "submit" ],
+        current_step: "review"
+      ))
+
+      expect(page).to have_css("li.usa-step-indicator__segment", count: 3)
+      expect(page).to have_css("li.usa-step-indicator__segment--current")
+      expect(page).to have_css(".usa-step-indicator__current-step", text: "2")
+    end
+  end
+
+  describe "unknown current_step (defensive)" do
+    it "renders without raising and marks no segment as current or complete" do
+      render_inline(described_class.new(steps: steps, current_step: :unknown_step))
+
+      expect(page).not_to have_css("li.usa-step-indicator__segment--current")
+      expect(page).not_to have_css("li.usa-step-indicator__segment--complete")
+    end
+
+    it "falls back to the humanized current_step in the heading when steps is empty" do
+      render_inline(described_class.new(steps: [], current_step: :unknown_step))
+
+      expect(page).to have_css(".usa-step-indicator__heading-text", text: "Unknown step")
+      expect(page).not_to have_css("li.usa-step-indicator__segment")
+    end
+  end
+
+  describe "extra classes & html attributes on the root <div>" do
+    it "appends extra classes after the USWDS classes" do
+      render_default(classes: "margin-top-2 extra")
+
+      expect(page).to have_css("div.usa-step-indicator.margin-top-2.extra")
+    end
+
+    it "keeps usa-step-indicator--counters together with extra classes" do
+      render_default(type: :counters, classes: "margin-top-2")
+
+      expect(page).to have_css("div.usa-step-indicator.usa-step-indicator--counters.margin-top-2")
+    end
+
+    it "forwards id, data-*, and other html attributes to the root <div>" do
+      render_default(id: "my-step", data: { test: "yes" })
+
+      expect(page).to have_css("div.usa-step-indicator#my-step[data-test='yes']")
+    end
+
+    it "prefers the dedicated classes: when html_attributes also carries :class" do
+      render_default(classes: "from-classes", class: "from-html-attrs")
+
+      expect(page).to have_css("div.usa-step-indicator.from-classes")
+      expect(page).not_to have_css("div.from-html-attrs")
+    end
+
+    it "does not override the built-in aria-label='progress' from html_attributes" do
+      # The component owns aria-label='progress' on the root. We intentionally
+      # do not expose it as an option to keep the component focused.
+      render_default
+
+      expect(page).to have_css("div.usa-step-indicator[aria-label='progress']")
+    end
+  end
+
+  describe "XSS safety" do
+    it "escapes step display names returned by i18n" do
+      I18n.backend.store_translations(
+        :en,
+        spec: { xss: { steps: { review: "<script>alert(1)</script>" } } }
+      )
+
+      render_inline(described_class.new(
+        steps: steps,
+        current_step: :review,
+        translation_scope: "spec.xss.steps"
+      ))
+
+      html = page.native.to_html
+      expect(html).not_to include("<script>alert(1)</script>")
+      expect(html).to include("&lt;script&gt;")
+    end
+  end
+end

--- a/spec/components/strata/us/step_indicator_component_spec.rb
+++ b/spec/components/strata/us/step_indicator_component_spec.rb
@@ -340,7 +340,6 @@ RSpec.describe Strata::US::StepIndicatorComponent, type: :component do
       expect(page).to have_css("div.usa-step-indicator.from-classes")
       expect(page).not_to have_css("div.from-html-attrs")
     end
-
   end
 
   describe "XSS safety" do

--- a/spec/components/strata/us/step_indicator_component_spec.rb
+++ b/spec/components/strata/us/step_indicator_component_spec.rb
@@ -67,6 +67,13 @@ RSpec.describe Strata::US::StepIndicatorComponent, type: :component do
       expect(page).to have_css("li.usa-step-indicator__segment--current", count: 1)
     end
 
+    it "adds aria-current='true' to the current segment only" do
+      render_default
+
+      expect(page).to have_css("li.usa-step-indicator__segment--current[aria-current='true']", count: 1)
+      expect(page).not_to have_css("li.usa-step-indicator__segment:not(.usa-step-indicator__segment--current)[aria-current]")
+    end
+
     it "shows the current step's display name in the heading text" do
       render_default
 

--- a/spec/components/strata/us/step_indicator_component_spec.rb
+++ b/spec/components/strata/us/step_indicator_component_spec.rb
@@ -54,11 +54,18 @@ RSpec.describe Strata::US::StepIndicatorComponent, type: :component do
   end
 
   describe "segment state — current (the active step)" do
-    it "marks it with both --current and --complete (per existing logic)" do
+    it "is not marked --complete" do
       render_default
 
       current = page.find("li.usa-step-indicator__segment--current")
-      expect(current[:class]).to include("usa-step-indicator__segment--complete")
+      expect(current[:class]).not_to include("usa-step-indicator__segment--complete")
+    end
+
+    it "does not render the .usa-sr-only completion text" do
+      render_default
+
+      current = page.find("li.usa-step-indicator__segment--current")
+      expect(current).not_to have_css(".usa-sr-only")
     end
 
     it "marks exactly one segment as --current" do

--- a/spec/dummy/app/views/passport_application_forms/show.html.erb
+++ b/spec/dummy/app/views/passport_application_forms/show.html.erb
@@ -16,11 +16,11 @@
 
   <h1><%= t(".title") %></h1>
 
-  <%= render partial: "strata/shared/step_indicator", locals: {
+  <%= render Strata::US::StepIndicatorComponent.new(
     type: :counters,
     steps: [:in_progress, :submitted, :decision_made],
     current_step: @passport_application_form.status
-  } %>
+  ) %>
 
   <div class="margin-top-4">
     <div class="border-top border-base-light padding-top-2 margin-top-2">

--- a/spec/lib/generators/strata/generators/application_form_views_generator_spec.rb
+++ b/spec/lib/generators/strata/generators/application_form_views_generator_spec.rb
@@ -252,11 +252,11 @@ RSpec.describe Strata::Generators::ApplicationFormViewsGenerator, type: :generat
       expect(File.read(layout_path)).to include('t("test_application_forms.actions.exit")')
     end
 
-    it "renders the step indicator partial" do
-      expect(File.read(layout_path)).to include('strata/shared/step_indicator')
+    it "renders the step indicator component" do
+      expect(File.read(layout_path)).to include("Strata::US::StepIndicatorComponent.new")
     end
 
-    it "passes step indicator locals from @flow_task" do
+    it "passes step indicator arguments from @flow_task" do
       content = File.read(layout_path)
       expect(content).to include("@flow_task.pages.map(&:name)")
       expect(content).to include("@flow_task.current_page.name")

--- a/spec/views/strata/shared/_step_indicator.html.erb_spec.rb
+++ b/spec/views/strata/shared/_step_indicator.html.erb_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# The shared/_step_indicator partial is preserved for backward compatibility with
+# host apps and generated layouts that already render it. It must continue to
+# forward every supported local through to Strata::US::StepIndicatorComponent.
+RSpec.describe "strata/shared/_step_indicator.html.erb", type: :view do
+  let(:steps) { [ :personal_info, :review, :submit ] }
+  let(:current_step) { :review }
+
+  def render_partial(locals)
+    render partial: "strata/shared/step_indicator", locals: locals
+  end
+
+  describe "forwarding locals to Strata::US::StepIndicatorComponent" do
+    it "renders the component's root markup with the given steps and current_step" do
+      render_partial(steps: steps, current_step: current_step)
+
+      expect(rendered).to have_css("div.usa-step-indicator[aria-label='progress']")
+      expect(rendered).to have_css("li.usa-step-indicator__segment", count: 3)
+      expect(rendered).to have_css("li.usa-step-indicator__segment--current")
+      expect(rendered).to have_css(".usa-step-indicator__current-step", text: "2")
+      expect(rendered).to have_css(".usa-step-indicator__total-steps", text: "of 3")
+    end
+
+    it "forwards type: :counters" do
+      render_partial(steps: steps, current_step: current_step, type: :counters)
+
+      expect(rendered).to have_css("div.usa-step-indicator.usa-step-indicator--counters")
+    end
+
+    it "forwards large_header: true" do
+      render_partial(steps: steps, current_step: current_step, large_header: true)
+
+      expect(rendered).to have_css(".usa-step-indicator__heading-text.font-heading-xl")
+    end
+
+    it "forwards header_first: true" do
+      render_partial(steps: steps, current_step: current_step, header_first: true)
+
+      expect(rendered).to have_css(
+        "div.usa-step-indicator > div.usa-step-indicator__header.margin-bottom-2 + ol.usa-step-indicator__segments"
+      )
+    end
+
+    it "forwards translation_scope" do
+      I18n.backend.store_translations(
+        :en,
+        spec: { partial_step_indicator: { steps: { review: "Forwarded scope label" } } }
+      )
+
+      render_partial(
+        steps: steps,
+        current_step: current_step,
+        translation_scope: "spec.partial_step_indicator.steps"
+      )
+
+      expect(rendered).to have_css(".usa-step-indicator__heading-text", text: "Forwarded scope label")
+      expect(rendered).to have_css(".usa-step-indicator__segment-label", text: "Forwarded scope label")
+    end
+
+    it "forwards all locals together (matches the call sites in show templates)" do
+      render_partial(
+        type: :counters,
+        steps: [ :in_progress, :submitted, :decision_made ],
+        current_step: :submitted,
+        large_header: true,
+        header_first: true
+      )
+
+      expect(rendered).to have_css("div.usa-step-indicator.usa-step-indicator--counters")
+      expect(rendered).to have_css(
+        "div.usa-step-indicator__header.margin-bottom-2 + ol.usa-step-indicator__segments"
+      )
+      expect(rendered).to have_css(".usa-step-indicator__heading-text.font-heading-xl", text: "In review")
+      expect(rendered).to have_css(".usa-step-indicator__current-step", text: "2")
+    end
+  end
+
+  describe "default behavior preserved" do
+    it "renders without optional locals (only steps + current_step required)" do
+      render_partial(steps: steps, current_step: current_step)
+
+      expect(rendered).not_to have_css(".usa-step-indicator--counters")
+      expect(rendered).not_to have_css(".font-heading-xl")
+      expect(rendered).not_to have_css(".usa-step-indicator__header.margin-bottom-2")
+    end
+  end
+end

--- a/spec/views/strata/shared/_step_indicator.html.erb_spec.rb
+++ b/spec/views/strata/shared/_step_indicator.html.erb_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "strata/shared/_step_indicator.html.erb", type: :view do
     it "renders the component's root markup with the given steps and current_step" do
       render_partial(steps: steps, current_step: current_step)
 
-      expect(rendered).to have_css("div.usa-step-indicator[aria-label='progress']")
+      expect(rendered).to have_css("div.usa-step-indicator")
       expect(rendered).to have_css("li.usa-step-indicator__segment", count: 3)
       expect(rendered).to have_css("li.usa-step-indicator__segment--current")
       expect(rendered).to have_css(".usa-step-indicator__current-step", text: "2")


### PR DESCRIPTION
## Changes

- Extracted the strata/shared/_step_indicator partial into a new ViewComponent, Strata::US::StepIndicatorComponent.                                                                                                                     
- Updated render locations in the repo to use the new component instead of the partial.
- `strata/shared/_step_indicator.html.erb` still exists (with a deprecation comment) so that all users of Strata that are rendering the partial will continue to work.
- Added unit tests for the new component.
- Updated `uswds-components.md` with usage description.
- Raises an ArgumentError when current_step is not a member of the list of steps.

## Context

Issue https://github.com/navapbc/strata-sdk-rails/issues/329

The issue specified a new `Strata::StepIndicatorComponent` component but since this appears to be a USWDS component I created it under the `Strata::US` namespace.


## Testing

- Compared the output of Lookbook previews before and after these changes.
- Rendered the Passport Application show page to verify output.
