### PR TITLE
Implement loops within application form flows

### DIFF
--- a/app/models/strata/flows/application_form_controller.rb
+++ b/app/models/strata/flows/application_form_controller.rb
@@ -72,11 +72,10 @@ module Strata::Flows
 
           # /{record_class}/:id/update_{question_page_name} (or nested under loop child)
           define_method(page.update_pathname) do
-            target_record = if page.in_loop?
-              flow_record.public_send(page.loop.association).find(params[:id])
-            else
-              flow_record
-            end
+            # For loop pages, reuse the loop_record already resolved by set_flow_task
+            # so that assign_attributes/errors land on the same instance the view
+            # renders, preserving submitted values across a re-render.
+            target_record = page.in_loop? ? @flow_task.loop_record : flow_record
 
             record_class_name = target_record.class.name.underscore.to_sym
             form_params = params.require(record_class_name).permit(*(page.attributes(target_record.class)))

--- a/app/models/strata/flows/application_form_controller.rb
+++ b/app/models/strata/flows/application_form_controller.rb
@@ -23,6 +23,15 @@ module Strata::Flows
       raise NotImplementedError, "#{self.class.name} must define #flow_record"
     end
 
+    # Resolves the flow record id from request params, handling both top-level
+    # routes (where params[:id] is the flow record) and loop-nested routes
+    # (where params[:id] is the loop child and params["<flow_class>_id"] is
+    # the flow record).
+    def flow_record_id
+      parent_key = "#{controller_name.singularize}_id"
+      params[parent_key] || params[:id]
+    end
+
     class_methods do
       def flow(flow_class)
         before_action :set_flow
@@ -37,7 +46,11 @@ module Strata::Flows
 
         # Set a @flow_task instance that can provide completion methods and routing helpers.
         define_method(:set_flow_task) do
-          @flow_page, @flow_task = flow_class.find_page_and_task_by_action(flow_record, request.path_parameters[:action])
+          @flow_page, @flow_task = flow_class.find_page_and_task_by_action(
+            flow_record,
+            request.path_parameters[:action],
+            request.path_parameters
+          )
         end
 
         # Redirect to start_path if the current page's task has unmet dependencies.
@@ -49,27 +62,34 @@ module Strata::Flows
           end
         end
 
-        # For each question page, define the edit and update paths.
-        flow_class.pages.each_with_index do |page, page_idx|
-          # /{record_class}/:id/edit_{question_page_name}
+        # For each question page (including pages inside loops), define the edit
+        # and update actions. Action names are namespaced by loop name for loop
+        # pages (e.g. update_prior_employer_business_name).
+        flow_class.all_pages.each do |page|
+          # /{record_class}/:id/edit_{question_page_name} (or nested under loop child)
           define_method(page.edit_pathname) do
           end
 
-          # /{record_class}/:id/update_{question_page_name}
+          # /{record_class}/:id/update_{question_page_name} (or nested under loop child)
           define_method(page.update_pathname) do
-            # Permit attributes based on the fields defined on the question page
-            record_class_name = flow_record.class.name.underscore.to_sym
-            form_params = params.require(record_class_name).permit(*(page.attributes(flow_record.class)))
-            flow_record.assign_attributes(form_params)
+            target_record = if page.in_loop?
+              flow_record.public_send(page.loop.association).find(params[:id])
+            else
+              flow_record
+            end
 
-            if flow_record.valid? && flow_record.save(context: page.name)
+            record_class_name = target_record.class.name.underscore.to_sym
+            form_params = params.require(record_class_name).permit(*(page.attributes(target_record.class)))
+            target_record.assign_attributes(form_params)
+
+            if target_record.valid? && target_record.save(context: page.name)
               redirect_to @flow_task.next_path || (@flow.tasks.length == 1 ? @flow.end_path : @flow.start_path)
             else
               # Allow custom error-handling behaviors by defining :on_flow_update_invalid
               if respond_to?(:on_flow_update_invalid)
                 on_flow_update_invalid
               else
-                flash.now[:errors] = flow_record.errors.full_messages
+                flash.now[:errors] = target_record.errors.full_messages
               end
 
               render page.edit_pathname, status: :unprocessable_content

--- a/app/models/strata/flows/application_form_controller.rb
+++ b/app/models/strata/flows/application_form_controller.rb
@@ -49,7 +49,7 @@ module Strata::Flows
           @flow_page, @flow_task = flow_class.find_page_and_task_by_action(
             flow_record,
             request.path_parameters[:action],
-            request.path_parameters
+            request.path_parameters[:id]
           )
         end
 

--- a/app/models/strata/flows/application_form_controller.rb
+++ b/app/models/strata/flows/application_form_controller.rb
@@ -87,7 +87,7 @@ module Strata::Flows
             else
               # Allow custom error-handling behaviors by defining :on_flow_update_invalid
               if respond_to?(:on_flow_update_invalid)
-                on_flow_update_invalid
+                on_flow_update_invalid(target_record)
               else
                 flash.now[:errors] = target_record.errors.full_messages
               end

--- a/app/models/strata/flows/application_form_flow.rb
+++ b/app/models/strata/flows/application_form_flow.rb
@@ -99,8 +99,10 @@ module Strata::Flows
 
       # Defines a loop over a has_many association on the flow record.
       # When association: is omitted, it defaults to the loop name.
-      def loop(loop_name, association: nil, &block)
-        @current_loop = Loop.new(loop_name, association: association)
+      # `scope:` optionally narrows the association — accepts a Symbol naming
+      # a scope on the relation, or a Proc that receives and returns a relation.
+      def loop(loop_name, association: nil, scope: nil, &block)
+        @current_loop = Loop.new(loop_name, association: association, scope: scope)
         @current_task.pages.push(@current_loop)
         block.call
         @current_loop = nil

--- a/app/models/strata/flows/application_form_flow.rb
+++ b/app/models/strata/flows/application_form_flow.rb
@@ -15,6 +15,12 @@ module Strata::Flows
   #       question_page :leave_dates
   #       question_page :supporting_documents, if: ->(app) { app.leave_type_medical? }
   #     end
+  #     task :prior_employment do
+  #       loop :prior_employer, association: :prior_employers do
+  #         question_page :business_name
+  #         question_page :role
+  #       end
+  #     end
   #   end
   module ApplicationFormFlow
     extend ActiveSupport::Concern
@@ -38,10 +44,20 @@ module Strata::Flows
         tasks.flat_map(&:pages)
       end
 
+      # Returns the flat sequence of QuestionPages across the flow, with each
+      # Loop expanded in place into its enclosed pages.
+      def all_pages
+        tasks.flat_map do |task|
+          task.pages.flat_map do |item|
+            item.is_a?(Loop) ? item.pages : [ item ]
+          end
+        end
+      end
+
       # Returns all routes that can be generated when used in
       # combination with ApplicationFormController
       def generated_routes
-        tasks.flat_map(&:pages).flat_map do |page|
+        all_pages.flat_map do |page|
           [ page.edit_pathname, page.update_pathname ]
         end
       end
@@ -71,9 +87,23 @@ module Strata::Flows
       # If no fields are provided, we assume that the page
       # has one field which matches the name of the page.
       def question_page(page_name, if: nil, fields: nil)
-        page = QuestionPage.new(page_name, if:, fields:)
-        @current_task.pages.push(page)
+        page = QuestionPage.new(page_name, if:, fields:, loop: @current_loop)
+        if @current_loop.present?
+          @current_loop.pages.push(page)
+        else
+          @current_task.pages.push(page)
+        end
         contexts.push(page_name)
+        validate_unique_action_names!
+      end
+
+      # Defines a loop over a has_many association on the flow record.
+      # When association: is omitted, it defaults to the loop name.
+      def loop(loop_name, association: nil, &block)
+        @current_loop = Loop.new(loop_name, association: association)
+        @current_task.pages.push(@current_loop)
+        block.call
+        @current_loop = nil
       end
 
       # A start page to return to when exiting out of a
@@ -96,12 +126,23 @@ module Strata::Flows
         @end_pathname = path
       end
 
-      def find_page_and_task_by_action(flow_record, action)
+      def find_page_and_task_by_action(flow_record, action, params = {})
+        action_sym = action.to_sym
+
         tasks.each do |task|
-          task.pages.each_with_index do |page, page_idx|
-            # Search for the current page based on the request action
-            if [ page.edit_pathname.to_sym, page.update_pathname.to_sym ].include?(action.to_sym)
-              return page, TaskEvaluator.new(task, flow_record, page_idx)
+          task.pages.each_with_index do |item, page_idx|
+            if item.is_a?(Loop)
+              item.pages.each_with_index do |loop_page, loop_page_idx|
+                next unless [ loop_page.edit_pathname.to_sym, loop_page.update_pathname.to_sym ].include?(action_sym)
+
+                loop_record = resolve_loop_record(item, flow_record, params)
+                return loop_page, TaskEvaluator.new(
+                  task, flow_record, page_idx,
+                  loop_record: loop_record, loop_page_idx: loop_page_idx
+                )
+              end
+            elsif [ item.edit_pathname.to_sym, item.update_pathname.to_sym ].include?(action_sym)
+              return item, TaskEvaluator.new(task, flow_record, page_idx)
             end
           end
         end
@@ -114,6 +155,7 @@ module Strata::Flows
 
         tasks.each do |task|
           task.pages.each do |page|
+            next if page.is_a?(Loop)
             node_name = page.name
             fields = page.fields.flat_map do |field|
               if field.is_a?(Hash)
@@ -133,10 +175,11 @@ module Strata::Flows
           end
 
           diagram += "  subgraph t_#{task.name}[Task: #{task.name}]\n"
-          if task.pages.length < 2
-            diagram += "    #{task.pages.first.name}\n"
+          rendered_pages = task.pages.reject { |p| p.is_a?(Loop) }
+          if rendered_pages.length < 2
+            diagram += "    #{rendered_pages.first.name}\n" if rendered_pages.first
           else
-            task.pages.each_cons(2) do |a, b|
+            rendered_pages.each_cons(2) do |a, b|
               diagram += "    #{a.name} --> #{b.name}\n"
             end
           end
@@ -148,6 +191,22 @@ module Strata::Flows
         end
 
         diagram
+      end
+
+      private
+
+      def resolve_loop_record(loop_node, flow_record, params)
+        return nil unless params[:id]
+
+        loop_node.records_for(flow_record).find(params[:id])
+      end
+
+      def validate_unique_action_names!
+        pathnames = all_pages.flat_map { |p| [ p.edit_pathname, p.update_pathname ] }
+        duplicates = pathnames.tally.select { |_, count| count > 1 }.keys
+        return if duplicates.empty?
+
+        raise ArgumentError, "duplicate action name(s) in flow: #{duplicates.join(', ')}"
       end
     end
 

--- a/app/models/strata/flows/application_form_flow.rb
+++ b/app/models/strata/flows/application_form_flow.rb
@@ -128,7 +128,7 @@ module Strata::Flows
         @end_pathname = path
       end
 
-      def find_page_and_task_by_action(flow_record, action, params = {})
+      def find_page_and_task_by_action(flow_record, action, id_param = nil)
         action_sym = action.to_sym
 
         tasks.each do |task|
@@ -137,7 +137,7 @@ module Strata::Flows
               item.pages.each_with_index do |loop_page, loop_page_idx|
                 next unless [ loop_page.edit_pathname.to_sym, loop_page.update_pathname.to_sym ].include?(action_sym)
 
-                loop_record = resolve_loop_record(item, flow_record, params)
+                loop_record = resolve_loop_record(item, flow_record, id_param)
                 return loop_page, TaskEvaluator.new(
                   task, flow_record, page_idx,
                   loop_record: loop_record, loop_page_idx: loop_page_idx
@@ -197,10 +197,10 @@ module Strata::Flows
 
       private
 
-      def resolve_loop_record(loop_node, flow_record, params)
-        return nil unless params[:id]
+      def resolve_loop_record(loop_node, flow_record, id_param)
+        return nil unless id_param
 
-        loop_node.records_for(flow_record).find(params[:id])
+        loop_node.records_for(flow_record).find(id_param)
       end
 
       def validate_unique_action_names!

--- a/app/models/strata/flows/loop.rb
+++ b/app/models/strata/flows/loop.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Strata::Flows
+  # Represents a sequence of question pages that iterates over a has_many
+  # association on the flow record. Each child record is walked through the
+  # same set of pages before the cursor advances to the next child.
+  class Loop
+    attr_accessor :name, :association, :pages
+
+    def initialize(name, association: nil, pages: [])
+      @name = name
+      @association = association || name
+      @pages = pages
+    end
+
+    def records_for(flow_record)
+      flow_record.public_send(@association)
+    end
+
+    def record_class(flow_record)
+      flow_record.class.reflect_on_association(@association).klass
+    end
+
+    def started?(flow_record)
+      records_for(flow_record).any? do |child|
+        @pages.any? { |page| page.completed?(child) }
+      end
+    end
+
+    def completed?(flow_record)
+      records_for(flow_record).all? do |child|
+        @pages.all? { |page| page.completed?(child) }
+      end
+    end
+  end
+end

--- a/app/models/strata/flows/loop.rb
+++ b/app/models/strata/flows/loop.rb
@@ -4,17 +4,24 @@ module Strata::Flows
   # Represents a sequence of question pages that iterates over a has_many
   # association on the flow record. Each child record is walked through the
   # same set of pages before the cursor advances to the next child.
+  #
+  # `scope:` optionally narrows the association — accepts a Symbol naming a
+  # scope on the relation, or a Proc that receives the relation and returns
+  # a filtered one. The filtered set drives traversal, completion, and child
+  # lookup, so records outside the scope are skipped and cannot be edited.
   class Loop
-    attr_accessor :name, :association, :pages
+    attr_accessor :name, :association, :scope, :pages
 
-    def initialize(name, association: nil, pages: [])
+    def initialize(name, association: nil, scope: nil, pages: [])
       @name = name
       @association = association || name
+      @scope = scope
       @pages = pages
     end
 
     def records_for(flow_record)
-      flow_record.public_send(@association)
+      base = flow_record.public_send(@association)
+      apply_scope(base)
     end
 
     def record_class(flow_record)
@@ -30,6 +37,18 @@ module Strata::Flows
     def completed?(flow_record)
       records_for(flow_record).all? do |child|
         @pages.all? { |page| page.completed?(child) }
+      end
+    end
+
+    private
+
+    def apply_scope(records)
+      return records if @scope.nil?
+
+      case @scope
+      when Symbol then records.public_send(@scope)
+      when Proc then @scope.call(records)
+      else raise ArgumentError, "Loop scope must be a Symbol or Proc, got #{@scope.class}"
       end
     end
   end

--- a/app/models/strata/flows/question_page.rb
+++ b/app/models/strata/flows/question_page.rb
@@ -34,7 +34,7 @@ module Strata::Flows
     def edit_path(flow_record, loop_record = nil)
       if in_loop?
         send(
-          "#{edit_pathname}_#{flow_record.class.name.underscore}_#{loop_record.class.name.underscore}_path",
+          "#{edit_pathname}_#{flow_record.class.name.underscore}_#{@loop.association.to_s.singularize}_path",
           flow_record, loop_record
         )
       else
@@ -49,7 +49,7 @@ module Strata::Flows
     def update_path(flow_record, loop_record = nil)
       if in_loop?
         send(
-          "#{update_pathname}_#{flow_record.class.name.underscore}_#{loop_record.class.name.underscore}_path",
+          "#{update_pathname}_#{flow_record.class.name.underscore}_#{@loop.association.to_s.singularize}_path",
           flow_record, loop_record
         )
       else

--- a/app/models/strata/flows/question_page.rb
+++ b/app/models/strata/flows/question_page.rb
@@ -4,14 +4,19 @@ module Strata::Flows
   # Represents an individual question page with a set of input fields.
   class QuestionPage
     include Rails.application.routes.url_helpers
-    attr_accessor :name, :fields
+    attr_accessor :name, :fields, :loop
 
-    def initialize(name, if: nil, fields: nil)
+    def initialize(name, if: nil, fields: nil, loop: nil)
       reserved_attributes = { if: }
 
       @name = name
       @if = reserved_attributes[:if]
       @fields = fields || [ @name.to_sym ]
+      @loop = loop
+    end
+
+    def in_loop?
+      @loop.present?
     end
 
     def needed?(record)
@@ -23,19 +28,33 @@ module Strata::Flows
     end
 
     def edit_pathname
-      "edit_#{@name}"
+      in_loop? ? "edit_#{@loop.name}_#{@name}" : "edit_#{@name}"
     end
 
-    def edit_path(record)
-      send("#{edit_pathname}_#{record.class.name.underscore}_path", record)
+    def edit_path(flow_record, loop_record = nil)
+      if in_loop?
+        send(
+          "#{edit_pathname}_#{flow_record.class.name.underscore}_#{loop_record.class.name.underscore}_path",
+          flow_record, loop_record
+        )
+      else
+        send("#{edit_pathname}_#{flow_record.class.name.underscore}_path", flow_record)
+      end
     end
 
     def update_pathname
-      "update_#{@name}"
+      in_loop? ? "update_#{@loop.name}_#{@name}" : "update_#{@name}"
     end
 
-    def update_path(record)
-      send("#{update_pathname}_#{record.class.name.underscore}_path", record)
+    def update_path(flow_record, loop_record = nil)
+      if in_loop?
+        send(
+          "#{update_pathname}_#{flow_record.class.name.underscore}_#{loop_record.class.name.underscore}_path",
+          flow_record, loop_record
+        )
+      else
+        send("#{update_pathname}_#{flow_record.class.name.underscore}_path", flow_record)
+      end
     end
 
     # Returns the list of permitted parameter keys for this page's fields,

--- a/app/models/strata/flows/task.rb
+++ b/app/models/strata/flows/task.rb
@@ -12,11 +12,15 @@ module Strata::Flows
     end
 
     def started?(record)
-      @pages.any? { |page| page.completed?(record) }
+      @pages.any? do |item|
+        item.is_a?(Loop) ? item.started?(record) : item.completed?(record)
+      end
     end
 
     def completed?(record)
-      @pages.all? { |page| page.completed?(record) }
+      @pages.all? do |item|
+        item.completed?(record)
+      end
     end
 
     def dependencies_met?(flow)
@@ -28,9 +32,44 @@ module Strata::Flows
       return nil if @pages.empty?
 
       if !started?(record) || completed?(record)
-        @pages.first.edit_path(record)
+        first_path(record)
       else
-        @pages.find { |page| !page.completed?(record) }.edit_path(record)
+        first_incomplete_path(record)
+      end
+    end
+
+    private
+
+    def first_path(record)
+      @pages.each do |item|
+        path = enter_forward(item, record)
+        return path if path
+      end
+      nil
+    end
+
+    def first_incomplete_path(record)
+      @pages.each do |item|
+        if item.is_a?(Loop)
+          item.records_for(record).each do |child|
+            incomplete = item.pages.find { |p| !p.completed?(child) }
+            return incomplete.edit_path(record, child) if incomplete
+          end
+        elsif !item.completed?(record)
+          return item.edit_path(record)
+        end
+      end
+      nil
+    end
+
+    def enter_forward(item, record)
+      if item.is_a?(Loop)
+        first_child = item.records_for(record).first
+        return nil unless first_child
+        first_page = item.pages.find { |p| p.needed?(first_child) }
+        first_page&.edit_path(record, first_child)
+      else
+        item.needed?(record) ? item.edit_path(record) : nil
       end
     end
   end

--- a/app/models/strata/flows/task_evaluator.rb
+++ b/app/models/strata/flows/task_evaluator.rb
@@ -49,134 +49,85 @@ module Strata::Flows
       in_loop? ? current_page.update_path(@record, @loop_record) : current_page.update_path(@record)
     end
 
+    # Path to the previous page, or nil if at the start of the task.
     def prev_path
-      if in_loop?
-        within = step_within_loop_backward
-        return within if within
-      end
-
-      walk_outer_backward(@current_page_idx)
+      step(:backward)
     end
 
+    # Path to the next page, or nil if at the end of the task.
     def next_path
-      if in_loop?
-        within = step_within_loop_forward
-        return within if within
-      end
-
-      walk_outer_forward(@current_page_idx)
+      step(:forward)
     end
 
     private
 
-    def step_within_loop_forward
-      loop_node = current_loop
-
-      idx = @loop_page_idx + 1
-      while idx < loop_node.pages.length
-        page = loop_node.pages[idx]
-        return page.edit_path(@record, @loop_record) if page.needed?(@loop_record)
-        idx += 1
+    # If the cursor is inside a Loop, try to move within it first; otherwise
+    # (or if the loop is exhausted) walk the task's outer pages.
+    def step(direction)
+      if in_loop?
+        within = step_within_loop(direction)
+        return within if within
       end
 
-      advance_to_next_loop_record(loop_node)
+      walk_outer(@current_page_idx, direction)
     end
 
-    def step_within_loop_backward
+    # Move within the current Loop: first try an adjacent page on the active
+    # child record, then fall through to the next child record's first
+    # needed page. Returns nil when the loop has nothing more in that
+    # direction.
+    def step_within_loop(direction)
       loop_node = current_loop
+      page = traverse(loop_node.pages, @loop_page_idx, direction)
+             .find { |p| p.needed?(@loop_record) }
+      return page.edit_path(@record, @loop_record) if page
 
-      idx = @loop_page_idx - 1
-      while idx >= 0
-        page = loop_node.pages[idx]
-        return page.edit_path(@record, @loop_record) if page.needed?(@loop_record)
-        idx -= 1
-      end
-
-      retreat_to_previous_loop_record(loop_node)
-    end
-
-    def advance_to_next_loop_record(loop_node)
       records = loop_node.records_for(@record)
       current_idx = records.find_index(@loop_record)
       return nil unless current_idx
 
-      next_idx = current_idx + 1
-      while next_idx < records.length
-        child = records[next_idx]
-        page = first_needed_page(loop_node.pages, child)
-        return page.edit_path(@record, child) if page
-        next_idx += 1
-      end
-
-      nil
+      enter_loop(loop_node, traverse(records, current_idx, direction), direction)
     end
 
-    def retreat_to_previous_loop_record(loop_node)
-      records = loop_node.records_for(@record)
-      current_idx = records.find_index(@loop_record)
-      return nil unless current_idx
-
-      prev_idx = current_idx - 1
-      while prev_idx >= 0
-        child = records[prev_idx]
-        page = last_needed_page(loop_node.pages, child)
-        return page.edit_path(@record, child) if page
-        prev_idx -= 1
-      end
-
-      nil
-    end
-
-    def walk_outer_forward(starting_idx)
-      idx = starting_idx + 1
-      while idx < @task.pages.length
-        path = enter_forward(@task.pages[idx])
+    # Walk the task's top-level pages from `starting_idx` and return the
+    # path of the first item we can enter.
+    def walk_outer(starting_idx, direction)
+      traverse(@task.pages, starting_idx, direction).each do |item|
+        path = enter(item, direction)
         return path if path
-        idx += 1
       end
       nil
     end
 
-    def walk_outer_backward(starting_idx)
-      idx = starting_idx - 1
-      while idx >= 0
-        path = enter_backward(@task.pages[idx])
-        return path if path
-        idx -= 1
+    # Enter a single top-level item: a QuestionPage's edit path if needed,
+    # or the first reachable page of a Loop.
+    def enter(item, direction)
+      if item.is_a?(Loop)
+        enter_loop(item, ordered(item.records_for(@record), direction), direction)
+      elsif item.needed?(@record)
+        item.edit_path(@record)
+      end
+    end
+
+    # Walk `records` (already ordered for the direction) and return the
+    # edit path of the first child whose first needed page exists.
+    def enter_loop(loop_node, records, direction)
+      records.each do |child|
+        page = ordered(loop_node.pages, direction).find { |p| p.needed?(child) }
+        return page.edit_path(@record, child) if page
       end
       nil
     end
 
-    def enter_forward(item)
-      if item.is_a?(Loop)
-        item.records_for(@record).each do |child|
-          page = first_needed_page(item.pages, child)
-          return page.edit_path(@record, child) if page
-        end
-        nil
-      else
-        item.needed?(@record) ? item.edit_path(@record) : nil
-      end
+    # Elements of `arr` adjacent to `idx`, ordered so the nearest comes
+    # first: items after `idx` forward, items before `idx` (reversed) backward.
+    def traverse(arr, idx, direction)
+      direction == :forward ? (arr[(idx + 1)..] || []) : arr.first(idx).reverse
     end
 
-    def enter_backward(item)
-      if item.is_a?(Loop)
-        item.records_for(@record).reverse_each do |child|
-          page = last_needed_page(item.pages, child)
-          return page.edit_path(@record, child) if page
-        end
-        nil
-      else
-        item.needed?(@record) ? item.edit_path(@record) : nil
-      end
-    end
-
-    def first_needed_page(pages, child_record)
-      pages.find { |p| p.needed?(child_record) }
-    end
-
-    def last_needed_page(pages, child_record)
-      pages.reverse.find { |p| p.needed?(child_record) }
+    # `arr` in iteration order for the direction (reversed when backward).
+    def ordered(arr, direction)
+      direction == :forward ? arr : arr.reverse
     end
   end
 end

--- a/app/models/strata/flows/task_evaluator.rb
+++ b/app/models/strata/flows/task_evaluator.rb
@@ -2,13 +2,18 @@
 
 module Strata::Flows
   # Evaluates a task within the context of a given record and the current page.
+  # When the current position is inside a Loop, the evaluator also carries the
+  # active child record and the index within the loop's pages so traversal
+  # methods can move both within the loop and out of it.
   class TaskEvaluator
-    attr_accessor :task, :record, :current_page_idx
+    attr_accessor :task, :record, :current_page_idx, :loop_record, :loop_page_idx
 
-    def initialize(task, record, current_page_idx)
+    def initialize(task, record, current_page_idx, loop_record: nil, loop_page_idx: nil)
       @task = task
       @record = record
       @current_page_idx = current_page_idx
+      @loop_record = loop_record
+      @loop_page_idx = loop_page_idx
     end
 
     def started?
@@ -27,36 +32,151 @@ module Strata::Flows
       @task.path
     end
 
-    def current_page
-      pages[@current_page_idx]
+    def current_loop
+      item = @task.pages[@current_page_idx]
+      item.is_a?(Loop) ? item : nil
     end
 
-    def prev_path
-      next_page_idx = @current_page_idx - 1
+    def in_loop?
+      current_loop.present?
+    end
 
-      while next_page_idx >= 0
-        page = pages[next_page_idx]
-        return page.edit_path(@record) if page.needed?(@record)
-        next_page_idx -= 1
-      end
-
-      nil
+    def current_page
+      in_loop? ? current_loop.pages[@loop_page_idx] : @task.pages[@current_page_idx]
     end
 
     def update_path
-      current_page.update_path(@record)
+      in_loop? ? current_page.update_path(@record, @loop_record) : current_page.update_path(@record)
+    end
+
+    def prev_path
+      if in_loop?
+        within = step_within_loop_backward
+        return within if within
+      end
+
+      walk_outer_backward(@current_page_idx)
     end
 
     def next_path
-      next_page_idx = @current_page_idx + 1
+      if in_loop?
+        within = step_within_loop_forward
+        return within if within
+      end
 
-      while next_page_idx <= pages.length - 1
-        page = pages[next_page_idx]
-        return page.edit_path(@record) if page.needed?(@record)
-        next_page_idx += 1
+      walk_outer_forward(@current_page_idx)
+    end
+
+    private
+
+    def step_within_loop_forward
+      loop_node = current_loop
+
+      idx = @loop_page_idx + 1
+      while idx < loop_node.pages.length
+        page = loop_node.pages[idx]
+        return page.edit_path(@record, @loop_record) if page.needed?(@loop_record)
+        idx += 1
+      end
+
+      advance_to_next_loop_record(loop_node)
+    end
+
+    def step_within_loop_backward
+      loop_node = current_loop
+
+      idx = @loop_page_idx - 1
+      while idx >= 0
+        page = loop_node.pages[idx]
+        return page.edit_path(@record, @loop_record) if page.needed?(@loop_record)
+        idx -= 1
+      end
+
+      retreat_to_previous_loop_record(loop_node)
+    end
+
+    def advance_to_next_loop_record(loop_node)
+      records = loop_node.records_for(@record)
+      current_idx = records.find_index(@loop_record)
+      return nil unless current_idx
+
+      next_idx = current_idx + 1
+      while next_idx < records.length
+        child = records[next_idx]
+        page = first_needed_page(loop_node.pages, child)
+        return page.edit_path(@record, child) if page
+        next_idx += 1
       end
 
       nil
+    end
+
+    def retreat_to_previous_loop_record(loop_node)
+      records = loop_node.records_for(@record)
+      current_idx = records.find_index(@loop_record)
+      return nil unless current_idx
+
+      prev_idx = current_idx - 1
+      while prev_idx >= 0
+        child = records[prev_idx]
+        page = last_needed_page(loop_node.pages, child)
+        return page.edit_path(@record, child) if page
+        prev_idx -= 1
+      end
+
+      nil
+    end
+
+    def walk_outer_forward(starting_idx)
+      idx = starting_idx + 1
+      while idx < @task.pages.length
+        path = enter_forward(@task.pages[idx])
+        return path if path
+        idx += 1
+      end
+      nil
+    end
+
+    def walk_outer_backward(starting_idx)
+      idx = starting_idx - 1
+      while idx >= 0
+        path = enter_backward(@task.pages[idx])
+        return path if path
+        idx -= 1
+      end
+      nil
+    end
+
+    def enter_forward(item)
+      if item.is_a?(Loop)
+        item.records_for(@record).each do |child|
+          page = first_needed_page(item.pages, child)
+          return page.edit_path(@record, child) if page
+        end
+        nil
+      else
+        item.needed?(@record) ? item.edit_path(@record) : nil
+      end
+    end
+
+    def enter_backward(item)
+      if item.is_a?(Loop)
+        item.records_for(@record).reverse_each do |child|
+          page = last_needed_page(item.pages, child)
+          return page.edit_path(@record, child) if page
+        end
+        nil
+      else
+        item.needed?(@record) ? item.edit_path(@record) : nil
+      end
+    end
+
+    def first_needed_page(pages, child_record)
+      pages.find { |p| p.needed?(child_record) }
+    end
+
+    def last_needed_page(pages, child_record)
+      pages.reverse.find { |p| p.needed?(child_record) }
     end
   end
 end

--- a/docs/multi-page-form-flows.md
+++ b/docs/multi-page-form-flows.md
@@ -8,14 +8,14 @@ Multi-Page Form Flows enable developers to define and build complex forms that s
 - **Automatically defined routes and controller actions**—Routes and controller actions for each of the form's pages are automatically generated.
 - **View components** for rendering unordered task lists and section states.
 - **Customizable**—Routes, controller actions, and views are all customizable if the default behavior does not meet the application's needs.
-- **[FUTURE] Built-in views**—Prebuilt views that show the current page, current task/section, and overall progress of the form.
-- **[FUTURE] Supports looping pattern**—Supports gathering information about multiple people or items in a single or multi-page loop.
+- **Supports looping pattern**—Supports gathering information about multiple people or items in a single or multi-page loop.
+- **Generated views**—Prebuilt views that display form fields based on the form flow definition.
 
 ## Design Principles
 
 ### Limit questions to one per page, where possible
 
-The form builder encourages a one-question-per-page approach.Through usability testing and secondary research, we’ve learned that taking a one-question-per-page approach increases people’s comfort and confidence and reduces their cognitive burden while moving through an application.
+The form builder encourages a one-question-per-page approach. Through usability testing and secondary research, we’ve learned that taking a one-question-per-page approach increases people’s comfort and confidence and reduces their cognitive burden while moving through an application.
 
 This approach is not a strict rule. In some cases, it might be a better user experience to pair some questions on the same page together, e.g., name and birth date.
 
@@ -60,6 +60,13 @@ class LeaveApplicationFormFlow
     question_page :leave_type
     question_page :leave_dates
   end
+
+  task :employment_details do
+    question_page :employers
+    loop :employments do
+      question_page :employer_notification
+    end
+  end
 end
 ```
 
@@ -94,6 +101,19 @@ For conditionally-rendered pages, provide an `if` option:
 question_page :supporting_documents, if: ->(record) { record.leave_type_medical? }
 ```
 
+Loops work off of associations within your primary model. Specify a different association with this option:
+
+```ruby
+loop :employment_details, association: :employments do ...
+```
+
+You can pass in scopes to only collect information on specific records:
+
+```ruby
+loop :employment_details, scope: :is_current, do ...
+loop :employment_details, scope: (employment) -> { employment.is_current }, do ...
+```
+
 ### Generating Routes
 
 Routes can be generated for your application form's controller:
@@ -110,7 +130,7 @@ class LeaveApplicationFormsController
 
     def flow_record
       # In most scenarios, you'll likely have a before_action that sets this, e.g.
-      # @leave_application_form ||= authorize(LeaveApplication.find(params[:id]), :update?)
+      # @leave_application_form ||= authorize(LeaveApplication.find(flow_record_id), :update?)
       @leave_application
     end
   end
@@ -120,12 +140,7 @@ In your `routes.rb` file, use your flow class to define the routes:
 
 ```ruby
 resources "leave_application_forms" do
-    member do
-      LeaveApplicationFormFlow.pages.each do |page|
-        get page.edit_pathname
-        patch page.update_pathname
-      end
-    end
+  mount_flow_routes LeaveApplicationFormFlow
 end
 ```
 
@@ -144,6 +159,12 @@ app/views/leave_application_forms/edit_name.html.erb
 app/views/leave_application_forms/edit_date_of_birth.html.erb
 ...
 ```
+
+The following types of form pages and fields are currently not supported:
+
+- Looping pages
+- Document upload form fields
+- form fields on associated records
 
 The following file is created or updated with default translation strings for each of the fields on your question page:
 

--- a/lib/strata/engine.rb
+++ b/lib/strata/engine.rb
@@ -16,6 +16,11 @@ module Strata
       end
     end
 
+    initializer "strata.routing_extensions", before: :set_routes_reloader_hook do
+      require "strata/flows/routing_extensions"
+      ActionDispatch::Routing::Mapper.include(Strata::Flows::RoutingExtensions)
+    end
+
     config.generators do |g|
       g.test_framework :rspec
     end

--- a/lib/strata/flows/routing_extensions.rb
+++ b/lib/strata/flows/routing_extensions.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Strata
+  module Flows
+    # Extends ActionDispatch::Routing::Mapper with a `mount_flow_routes` helper
+    # that generates all routes implied by an ApplicationFormFlow definition:
+    # member actions for top-level pages, and nested resources with member
+    # actions for loop pages.
+    #
+    # @example
+    #   resources :leave_applications, only: [ :index, :new, :show, :create ] do
+    #     member do
+    #       get :review
+    #       patch :submit
+    #     end
+    #
+    #     mount_flow_routes Flows::LeaveApplicationFlow
+    #   end
+    module RoutingExtensions
+      # Mounts edit/update routes for every QuestionPage in the flow.
+      #
+      # Must be called inside a `resources` block. The enclosing resource's
+      # controller is used for all generated actions unless `controller:` is
+      # explicitly provided.
+      def mount_flow_routes(flow_class, controller: nil)
+        target_controller = controller || parent_resource&.controller
+        raise ArgumentError, "mount_flow_routes must be called inside a resources block, or given an explicit controller:" unless target_controller
+
+        member do
+          flow_class.all_pages.reject(&:in_loop?).each do |page|
+            get page.edit_pathname
+            patch page.update_pathname
+          end
+        end
+
+        loop_nodes = flow_class.tasks.flat_map(&:pages).select { |item| item.is_a?(Strata::Flows::Loop) }
+        loop_nodes.each do |loop_node|
+          resources loop_node.association, only: [], controller: target_controller do
+            member do
+              loop_node.pages.each do |page|
+                get page.edit_pathname
+                patch page.update_pathname
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/app/controllers/sample_application_forms_controller.rb
+++ b/spec/dummy/app/controllers/sample_application_forms_controller.rb
@@ -51,6 +51,6 @@ class SampleApplicationFormsController < ApplicationController
   end
 
   def set_form
-    @sample_application_form = SampleApplicationForm.find(params[:id])
+    @sample_application_form = SampleApplicationForm.find(flow_record_id)
   end
 end

--- a/spec/dummy/app/flows/sample_flow.rb
+++ b/spec/dummy/app/flows/sample_flow.rb
@@ -12,7 +12,13 @@ class SampleFlow
   task :employment_details, depends_on: [ :personal_information ] do
     question_page :employer_name
   end
-  task :leave_details, depends_on: [ :employment_details ] do
+  task :prior_employment, depends_on: [ :employment_details ] do
+    loop :prior_employer, association: :sample_employment_details do
+      question_page :business_name
+      question_page :role
+    end
+  end
+  task :leave_details, depends_on: [ :prior_employment ] do
     question_page :leave_type
   end
   end_page :review

--- a/spec/dummy/app/models/sample_application_form.rb
+++ b/spec/dummy/app/models/sample_application_form.rb
@@ -4,6 +4,8 @@ class SampleApplicationForm < Strata::ApplicationForm
   include Strata::Flows::ApplicationFormValidations
   validate_flow SampleFlow
 
+  has_many :sample_employment_details, dependent: :destroy
+
   strata_attribute :date_of_birth, :memorable_date
 
   validates :applicant_name_first, presence: true, on: Flow::NAME

--- a/spec/dummy/app/models/sample_application_form.rb
+++ b/spec/dummy/app/models/sample_application_form.rb
@@ -4,7 +4,7 @@ class SampleApplicationForm < Strata::ApplicationForm
   include Strata::Flows::ApplicationFormValidations
   validate_flow SampleFlow
 
-  has_many :sample_employment_details, dependent: :destroy
+  has_many :sample_employment_details, -> { order(:id) }, dependent: :destroy
 
   strata_attribute :date_of_birth, :memorable_date
 

--- a/spec/dummy/app/models/sample_employment_detail.rb
+++ b/spec/dummy/app/models/sample_employment_detail.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class SampleEmploymentDetail < ApplicationRecord
+  belongs_to :sample_application_form
+
+  validates :business_name, presence: true, on: :business_name
+  validates :role, presence: true, on: :role
+end

--- a/spec/dummy/app/views/sample_application_forms/edit_prior_employer_business_name.html.erb
+++ b/spec/dummy/app/views/sample_application_forms/edit_prior_employer_business_name.html.erb
@@ -1,0 +1,8 @@
+<%= strata_form_with model: @flow_task.loop_record, url: @flow_task.update_path, method: :patch do |f| %>
+  <%= f.text_field :business_name, {
+    legend: t(".business_name_title"),
+    large_legend: true
+  } %>
+
+  <%= render partial: "form_buttons", locals: { back_path: @flow_task.prev_path || @flow.start_path, f: f } %>
+<% end %>

--- a/spec/dummy/app/views/sample_application_forms/edit_prior_employer_role.html.erb
+++ b/spec/dummy/app/views/sample_application_forms/edit_prior_employer_role.html.erb
@@ -1,0 +1,8 @@
+<%= strata_form_with model: @flow_task.loop_record, url: @flow_task.update_path, method: :patch do |f| %>
+  <%= f.text_field :role, {
+    legend: t(".role_title"),
+    large_legend: true
+  } %>
+
+  <%= render partial: "form_buttons", locals: { back_path: @flow_task.prev_path || @flow.start_path, f: f } %>
+<% end %>

--- a/spec/dummy/config/locales/sample_applications/en.yml
+++ b/spec/dummy/config/locales/sample_applications/en.yml
@@ -7,6 +7,9 @@ en:
       employment_details:
         title: Employment
         description: Tell us about your employer. You'll need to enter their legal name and their 9 digit federal employer identification number (FEIN or EIN).
+      prior_employment:
+        title: Prior Employment
+        description: Tell us about each of your prior employers. We'll walk you through each one.
       leave_details:
         title: Leave Details
         description: Tell us about the type of leave you're taking (Parental, Medical, Family Caregiving, or Military Exigency). You'll need to enter your leave dates and provide supporting documentation.
@@ -37,6 +40,10 @@ en:
       date_of_birth_title: When were you born?
     edit_employer_name:
       employer_name_title: Who is your employer?
+    edit_prior_employer_business_name:
+      business_name_title: What was the name of this prior employer?
+    edit_prior_employer_role:
+      role_title: What was your role at this prior employer?
     edit_leave_type:
       leave_type_title: Why do you need to take leave?
     review:

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -11,14 +11,11 @@ Rails.application.routes.draw do
 
   resources :sample_application_forms, only: [ :index, :new, :show, :create ] do
     member do
-      SampleFlow.pages.each do |page|
-        get page.edit_pathname
-        patch page.update_pathname
-      end
-
       get :review
       patch :submit
     end
+
+    mount_flow_routes SampleFlow
   end
 
   scope path: "/staff" do

--- a/spec/dummy/db/migrate/20260520120000_create_sample_employment_details.rb
+++ b/spec/dummy/db/migrate/20260520120000_create_sample_employment_details.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateSampleEmploymentDetails < ActiveRecord::Migration[8.0]
+  def change
+    create_table :sample_employment_details do |t|
+      t.references :sample_application_form, foreign_key: true
+      t.string :business_name
+      t.string :role
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_04_221320) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_20_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -56,7 +56,15 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_04_221320) do
     t.string "leave_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "reviewed", default: false
+  end
+
+  create_table "sample_employment_details", force: :cascade do |t|
+    t.bigint "sample_application_form_id"
+    t.string "business_name"
+    t.string "role"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["sample_application_form_id"], name: "index_sample_employment_details_on_sample_application_form_id"
   end
 
   create_table "strata_audit_lines", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -177,5 +185,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_04_221320) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "sample_employment_details", "sample_application_forms"
   add_foreign_key "strata_tasks", "users", column: "assignee_id", on_delete: :nullify
 end

--- a/spec/dummy/spec/controllers/sample_application_forms/sample_application_forms_controller_prior_employer_loop_spec.rb
+++ b/spec/dummy/spec/controllers/sample_application_forms/sample_application_forms_controller_prior_employer_loop_spec.rb
@@ -72,6 +72,22 @@ RSpec.describe SampleApplicationFormsController do
         expect(response).to have_http_status(:unprocessable_content)
         expect(child_b.reload.business_name).to be_nil
       end
+
+      it "preserves submitted values on the re-rendered form rather than reverting to the DB state" do
+        # child_a starts with business_name: "Acme". Submit an invalid value that
+        # passes type coercion but fails validation, then verify the form shows
+        # the submitted value (not the original "Acme").
+        patch :update_prior_employer_business_name, params: {
+          sample_application_form_id: application.id,
+          id: child_a.id,
+          sample_employment_detail: { business_name: "" },
+          locale: "en"
+        }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to have_field("sample_employment_detail[business_name]", with: "")
+        expect(response.body).not_to have_field("sample_employment_detail[business_name]", with: "Acme")
+      end
     end
   end
 

--- a/spec/dummy/spec/controllers/sample_application_forms/sample_application_forms_controller_prior_employer_loop_spec.rb
+++ b/spec/dummy/spec/controllers/sample_application_forms/sample_application_forms_controller_prior_employer_loop_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Exercises the loop-aware behaviors of ApplicationFormController.
+#
+# Fixtures introduced by this feature (created in the impl phase):
+#   - SampleEmploymentDetail model with :business_name and :role columns
+#   - has_many :sample_employment_details on SampleApplicationForm
+#   - A loop in SampleFlow over :sample_employment_details, named :prior_employer
+#   - Nested routes under sample_application_forms for the loop pages
+RSpec.describe SampleApplicationFormsController do
+  render_views
+
+  let(:application) { create(:sample_application_form, :submittable) }
+  let!(:child_a) { create(:sample_employment_detail, sample_application_form: application, business_name: "Acme", role: "Engineer") }
+  let!(:child_b) { create(:sample_employment_detail, sample_application_form: application, business_name: nil, role: nil) }
+
+  describe "GET #edit_prior_employer_business_name" do
+    it "renders for a specific child record" do
+      get :edit_prior_employer_business_name, params: {
+        sample_application_form_id: application.id,
+        id: child_b.id,
+        locale: "en"
+      }
+
+      expect(response).to have_http_status(:ok)
+      # Form should reference the child, not the parent
+      expect(response.body).to include(child_b.id.to_s)
+    end
+  end
+
+  describe "PATCH #update_prior_employer_business_name" do
+    context "with valid params" do
+      it "updates only the targeted child record and leaves siblings unchanged" do
+        original_child_a_business_name = child_a.business_name
+
+        patch :update_prior_employer_business_name, params: {
+          sample_application_form_id: application.id,
+          id: child_b.id,
+          sample_employment_detail: { business_name: "Globex" },
+          locale: "en"
+        }
+
+        expect(child_a.reload.business_name).to eq(original_child_a_business_name)
+        expect(child_b.reload.business_name).to eq("Globex")
+      end
+
+      it "redirects to the next loop page for the same child record (not last loop page)" do
+        patch :update_prior_employer_business_name, params: {
+          sample_application_form_id: application.id,
+          id: child_b.id,
+          sample_employment_detail: { business_name: "Globex" },
+          locale: "en"
+        }
+
+        expect(response).to redirect_to(
+          edit_prior_employer_role_sample_application_form_sample_employment_detail_path(application, child_b)
+        )
+      end
+    end
+
+    context "with invalid params" do
+      it "re-renders the edit page with errors and does not change the record" do
+        patch :update_prior_employer_business_name, params: {
+          sample_application_form_id: application.id,
+          id: child_b.id,
+          sample_employment_detail: { business_name: "" },
+          locale: "en"
+        }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(child_b.reload.business_name).to be_nil
+      end
+    end
+  end
+
+  describe "PATCH #update_prior_employer_role" do
+    context "when on the last loop page for a non-last child" do
+      it "redirects to the first loop page for the next child record" do
+        patch :update_prior_employer_role, params: {
+          sample_application_form_id: application.id,
+          id: child_a.id,
+          sample_employment_detail: { role: "Senior Engineer" },
+          locale: "en"
+        }
+
+        expect(response).to redirect_to(
+          edit_prior_employer_business_name_sample_application_form_sample_employment_detail_path(application, child_b)
+        )
+      end
+    end
+
+    context "when on the last loop page for the last child" do
+      before do
+        child_b.update!(business_name: "Globex")
+      end
+
+      it "exits the loop to the next top-level page" do
+        patch :update_prior_employer_role, params: {
+          sample_application_form_id: application.id,
+          id: child_b.id,
+          sample_employment_detail: { role: "Manager" },
+          locale: "en"
+        }
+
+        expect(response.location).not_to match(/prior_employer/)
+      end
+    end
+  end
+
+  describe "loop with empty relation" do
+    it "skips the loop on next_path from the page before it" do
+      application.sample_employment_details.destroy_all
+
+      patch :update_employer_name, params: {
+        id: application.id,
+        sample_application_form: { employer_name: "Initech" },
+        locale: "en"
+      }
+
+      # next_path should not land on a prior_employer route since there are no children
+      expect(response.location).not_to match(/prior_employer/)
+    end
+  end
+end

--- a/spec/dummy/spec/factories/sample_application_forms_factory.rb
+++ b/spec/dummy/spec/factories/sample_application_forms_factory.rb
@@ -9,4 +9,10 @@ FactoryBot.define do
       leave_type { "medical" }
     end
   end
+
+  factory :sample_employment_detail do
+    sample_application_form
+    business_name { "Acme Corp" }
+    role { "Engineer" }
+  end
 end

--- a/spec/lib/strata/flows/routing_extensions_spec.rb
+++ b/spec/lib/strata/flows/routing_extensions_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Strata::Flows::RoutingExtensions do
+  describe "#mount_flow_routes (via SampleFlow on the dummy app)" do
+    let(:routes) { Rails.application.routes.routes }
+
+    def route_for(name)
+      routes.find { |r| r.name == name }
+    end
+
+    it "generates member routes for top-level flow pages" do
+      expect(route_for("edit_name_sample_application_form")).not_to be_nil
+      expect(route_for("update_name_sample_application_form")).not_to be_nil
+      expect(route_for("edit_employer_name_sample_application_form")).not_to be_nil
+    end
+
+    it "dispatches top-level page routes to the parent controller" do
+      route = route_for("edit_name_sample_application_form")
+      expect(route.defaults[:controller]).to eq("sample_application_forms")
+      expect(route.defaults[:action]).to eq("edit_name")
+    end
+
+    it "generates nested member routes under the loop's association" do
+      route = route_for("edit_prior_employer_business_name_sample_application_form_sample_employment_detail")
+      expect(route).not_to be_nil
+      expect(route.path.spec.to_s).to match(%r{/sample_application_forms/:sample_application_form_id/sample_employment_details/:id/edit_prior_employer_business_name})
+    end
+
+    it "dispatches loop page routes to the parent controller" do
+      route = route_for("update_prior_employer_role_sample_application_form_sample_employment_detail")
+      expect(route).not_to be_nil
+      expect(route.defaults[:controller]).to eq("sample_application_forms")
+      expect(route.defaults[:action]).to eq("update_prior_employer_role")
+    end
+
+    it "leaves pre-existing member routes (review, submit) intact" do
+      expect(route_for("review_sample_application_form")).not_to be_nil
+      expect(route_for("submit_sample_application_form")).not_to be_nil
+    end
+  end
+
+  describe "when called outside a resources block" do
+    it "raises with a clear message" do
+      expect {
+        Rails.application.routes.draw do
+          mount_flow_routes SampleFlow
+        end
+      }.to raise_error(ArgumentError, /resources block/)
+    ensure
+      Rails.application.reload_routes!
+    end
+  end
+end

--- a/spec/models/strata/flows/application_form_flow_spec.rb
+++ b/spec/models/strata/flows/application_form_flow_spec.rb
@@ -167,6 +167,32 @@ RSpec.describe Strata::Flows::ApplicationFormFlow do
       expect(loop_node.association).to eq(:prior_employers)
     end
 
+    it "passes scope: through to the Loop node" do
+      scope_proc = ->(rel) { rel }
+      flow_with_scope = Class.new do
+        include Strata::Flows::ApplicationFormFlow
+
+        task :employment do
+          loop :prior_employer, association: :prior_employers, scope: :active do
+            question_page :business_name
+          end
+        end
+      end
+
+      flow_with_scope_proc = Class.new do
+        include Strata::Flows::ApplicationFormFlow
+
+        task :employment do
+          loop :prior_employer, association: :prior_employers, scope: scope_proc do
+            question_page :business_name
+          end
+        end
+      end
+
+      expect(flow_with_scope.tasks.first.pages.first.scope).to eq(:active)
+      expect(flow_with_scope_proc.tasks.first.pages.first.scope).to eq(scope_proc)
+    end
+
     it "back-references the loop on each enclosed QuestionPage" do
       loop_node = FlowWithLoop.tasks.find { |t| t.name == :employment }.pages[1]
 

--- a/spec/models/strata/flows/application_form_flow_spec.rb
+++ b/spec/models/strata/flows/application_form_flow_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe Strata::Flows::ApplicationFormFlow do
         page, evaluator = FlowWithLoop.find_page_and_task_by_action(
           flow_record,
           "edit_prior_employer_business_name",
-          { id: "xyz" }
+          "xyz"
         )
 
         expect(page.name).to eq(:business_name)

--- a/spec/models/strata/flows/application_form_flow_spec.rb
+++ b/spec/models/strata/flows/application_form_flow_spec.rb
@@ -104,4 +104,195 @@ RSpec.describe Strata::Flows::ApplicationFormFlow do
       end
     end
   end
+
+  describe "loop DSL" do
+    before do
+      flow_with_loop = Class.new do
+        include Strata::Flows::ApplicationFormFlow
+
+        task :personal_information do
+          question_page :name, fields: [ :applicant_name_first ]
+        end
+
+        task :employment do
+          question_page :employer_name
+          loop :prior_employer, association: :prior_employers do
+            question_page :business_name
+            question_page :role
+          end
+          question_page :years_employed
+        end
+
+        task :leave_details do
+          question_page :leave_type
+        end
+
+        end_page :review
+      end
+
+      stub_const("FlowWithLoop", flow_with_loop)
+    end
+
+    it "wraps loop pages in a Loop node within the task" do
+      employment_task = FlowWithLoop.tasks.find { |t| t.name == :employment }
+
+      expect(employment_task.pages.length).to eq(3)
+      expect(employment_task.pages[0]).to be_a(Strata::Flows::QuestionPage)
+      expect(employment_task.pages[0].name).to eq(:employer_name)
+
+      loop_node = employment_task.pages[1]
+      expect(loop_node).to be_a(Strata::Flows::Loop)
+      expect(loop_node.name).to eq(:prior_employer)
+      expect(loop_node.association).to eq(:prior_employers)
+      expect(loop_node.pages.map(&:name)).to eq([ :business_name, :role ])
+
+      expect(employment_task.pages[2]).to be_a(Strata::Flows::QuestionPage)
+      expect(employment_task.pages[2].name).to eq(:years_employed)
+    end
+
+    it "defaults the loop's association to its name when omitted in the DSL" do
+      flow_without_assoc = Class.new do
+        include Strata::Flows::ApplicationFormFlow
+
+        task :employment do
+          loop :prior_employers do
+            question_page :business_name
+          end
+        end
+      end
+
+      loop_node = flow_without_assoc.tasks.first.pages.first
+      expect(loop_node).to be_a(Strata::Flows::Loop)
+      expect(loop_node.name).to eq(:prior_employers)
+      expect(loop_node.association).to eq(:prior_employers)
+    end
+
+    it "back-references the loop on each enclosed QuestionPage" do
+      loop_node = FlowWithLoop.tasks.find { |t| t.name == :employment }.pages[1]
+
+      expect(loop_node.pages).to all(be_in_loop)
+      expect(loop_node.pages.map(&:loop).uniq).to eq([ loop_node ])
+    end
+
+    it "registers loop page names in the flow contexts (un-namespaced)" do
+      expect(FlowWithLoop.contexts).to include(:business_name, :role)
+    end
+
+    describe "#all_pages" do
+      it "returns the flat sequence of QuestionPages, expanding loops in place" do
+        names = FlowWithLoop.all_pages.map(&:name)
+        expect(names).to eq([
+          :name,
+          :employer_name,
+          :business_name,
+          :role,
+          :years_employed,
+          :leave_type
+        ])
+      end
+    end
+
+    describe "#generated_routes" do
+      it "includes namespaced action names for loop pages" do
+        expect(FlowWithLoop.generated_routes).to include(
+          "edit_prior_employer_business_name",
+          "update_prior_employer_business_name",
+          "edit_prior_employer_role",
+          "update_prior_employer_role"
+        )
+      end
+
+      it "keeps un-namespaced action names for top-level pages" do
+        expect(FlowWithLoop.generated_routes).to include(
+          "edit_name", "update_name",
+          "edit_employer_name", "update_employer_name",
+          "edit_years_employed", "update_years_employed",
+          "edit_leave_type", "update_leave_type"
+        )
+      end
+    end
+
+    describe "#find_page_and_task_by_action" do
+      let(:flow_record) do
+        Class.new do
+          attr_accessor :prior_employers
+
+          def initialize(prior_employers: [])
+            @prior_employers = prior_employers
+          end
+        end.new
+      end
+
+      it "finds top-level pages by un-namespaced action" do
+        page, evaluator = FlowWithLoop.find_page_and_task_by_action(flow_record, "edit_employer_name")
+
+        expect(page.name).to eq(:employer_name)
+        expect(evaluator.task.name).to eq(:employment)
+      end
+
+      it "finds loop pages by namespaced action and returns a loop-aware evaluator" do
+        child_record = Object.new
+        relation = Class.new do
+          def initialize(record)
+            @record = record
+          end
+
+          def find(_id)
+            @record
+          end
+        end.new(child_record)
+        flow_record.prior_employers = relation
+
+        page, evaluator = FlowWithLoop.find_page_and_task_by_action(
+          flow_record,
+          "edit_prior_employer_business_name",
+          { id: "xyz" }
+        )
+
+        expect(page.name).to eq(:business_name)
+        expect(page).to be_in_loop
+        expect(evaluator.task.name).to eq(:employment)
+        expect(evaluator.loop_record).to eq(child_record)
+      end
+
+      it "returns nil when the action does not match any page" do
+        page, evaluator = FlowWithLoop.find_page_and_task_by_action(flow_record, "edit_unknown")
+
+        expect(page).to be_nil
+        expect(evaluator).to be_nil
+      end
+    end
+
+    describe "collision detection" do
+      it "raises when two loop pages would generate the same namespaced action" do
+        expect {
+          Class.new do
+            include Strata::Flows::ApplicationFormFlow
+
+            task :employment do
+              loop :prior_employer, association: :prior_employers do
+                question_page :business_name
+                question_page :business_name
+              end
+            end
+          end
+        }.to raise_error(ArgumentError, /duplicate.*business_name/i)
+      end
+
+      it "raises when a loop page collides with a top-level page after namespacing" do
+        expect {
+          Class.new do
+            include Strata::Flows::ApplicationFormFlow
+
+            task :employment do
+              question_page :prior_employer_business_name
+              loop :prior_employer, association: :prior_employers do
+                question_page :business_name
+              end
+            end
+          end
+        }.to raise_error(ArgumentError, /duplicate.*prior_employer_business_name/i)
+      end
+    end
+  end
 end

--- a/spec/models/strata/flows/loop_spec.rb
+++ b/spec/models/strata/flows/loop_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Strata::Flows::Loop do
       expect(loop_node.name).to eq(:prior_employer)
       expect(loop_node.association).to eq(:prior_employers)
       expect(loop_node.pages).to eq([])
+      expect(loop_node.scope).to be_nil
     end
 
     it "defaults association to the loop name when not provided" do
@@ -45,17 +46,73 @@ RSpec.describe Strata::Flows::Loop do
       expect(loop_node.name).to eq(:prior_employers)
       expect(loop_node.association).to eq(:prior_employers)
     end
+
+    it "stores the scope when provided" do
+      scope = ->(rel) { rel }
+      loop_node = described_class.new(:prior_employers, scope: scope)
+
+      expect(loop_node.scope).to eq(scope)
+    end
   end
 
   describe "#records_for" do
+    let(:child_a) { PriorEmployer.new(business_name: "Acme") }
+    let(:child_b) { PriorEmployer.new(business_name: "Globex") }
+
     it "returns the association on the flow record" do
-      child_a = PriorEmployer.new(business_name: "Acme")
-      child_b = PriorEmployer.new(business_name: "Globex")
       flow_record = EmploymentForm.new(prior_employers: [ child_a, child_b ])
 
       loop_node = described_class.new(:prior_employer, association: :prior_employers)
 
       expect(loop_node.records_for(flow_record)).to eq([ child_a, child_b ])
+    end
+
+    context "with a Symbol scope" do
+      before do
+        scoped_relation_class = Class.new do
+          def initialize(records)
+            @records = records
+          end
+
+          def active
+            @records.select { |r| r.business_name == "Globex" }
+          end
+        end
+
+        stub_const("ScopedRelation", scoped_relation_class)
+      end
+
+      it "applies the named scope on the relation" do
+        flow_record = EmploymentForm.new(prior_employers: ScopedRelation.new([ child_a, child_b ]))
+
+        loop_node = described_class.new(:prior_employer, association: :prior_employers, scope: :active)
+
+        expect(loop_node.records_for(flow_record)).to eq([ child_b ])
+      end
+    end
+
+    context "with a Proc scope" do
+      it "calls the proc with the relation and returns its result" do
+        flow_record = EmploymentForm.new(prior_employers: [ child_a, child_b ])
+
+        loop_node = described_class.new(
+          :prior_employer,
+          association: :prior_employers,
+          scope: ->(records) { records.select { |r| r.business_name.start_with?("A") } }
+        )
+
+        expect(loop_node.records_for(flow_record)).to eq([ child_a ])
+      end
+    end
+
+    context "with an invalid scope type" do
+      it "raises ArgumentError" do
+        flow_record = EmploymentForm.new(prior_employers: [ child_a ])
+
+        loop_node = described_class.new(:prior_employer, association: :prior_employers, scope: "active")
+
+        expect { loop_node.records_for(flow_record) }.to raise_error(ArgumentError, /Symbol or Proc/)
+      end
     end
   end
 
@@ -86,6 +143,23 @@ RSpec.describe Strata::Flows::Loop do
       flow_record = EmploymentForm.new(prior_employers: [])
 
       expect(loop_node).to be_completed(flow_record)
+    end
+
+    it "only considers records inside the scope" do
+      scoped_loop = described_class.new(
+        :prior_employer,
+        association: :prior_employers,
+        pages: [ business_name_page, role_page ],
+        scope: ->(records) { records.select { |r| r.business_name == "Acme" } }
+      )
+
+      flow_record = EmploymentForm.new(prior_employers: [
+        PriorEmployer.new(business_name: "Acme", role: "Engineer"),
+        PriorEmployer.new(business_name: "Globex", role: nil)
+      ])
+
+      # The Globex record is outside the scope, so its missing :role doesn't fail completion.
+      expect(scoped_loop).to be_completed(flow_record)
     end
   end
 

--- a/spec/models/strata/flows/loop_spec.rb
+++ b/spec/models/strata/flows/loop_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Strata::Flows::Loop do
+  before do
+    child_class = Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :business_name, :string
+      attribute :role, :string
+      validates :business_name, presence: true, on: :business_name
+      validates :role, presence: true, on: :role
+    end
+
+    parent_class = Class.new do
+      include ActiveModel::Model
+      attr_accessor :prior_employers
+
+      def initialize(prior_employers: [])
+        @prior_employers = prior_employers
+      end
+    end
+
+    stub_const("PriorEmployer", child_class)
+    stub_const("EmploymentForm", parent_class)
+  end
+
+  let(:business_name_page) { Strata::Flows::QuestionPage.new(:business_name) }
+  let(:role_page) { Strata::Flows::QuestionPage.new(:role) }
+
+  describe "#initialize" do
+    it "stores name, association, and pages" do
+      loop_node = described_class.new(:prior_employer, association: :prior_employers)
+
+      expect(loop_node.name).to eq(:prior_employer)
+      expect(loop_node.association).to eq(:prior_employers)
+      expect(loop_node.pages).to eq([])
+    end
+
+    it "defaults association to the loop name when not provided" do
+      loop_node = described_class.new(:prior_employers)
+
+      expect(loop_node.name).to eq(:prior_employers)
+      expect(loop_node.association).to eq(:prior_employers)
+    end
+  end
+
+  describe "#records_for" do
+    it "returns the association on the flow record" do
+      child_a = PriorEmployer.new(business_name: "Acme")
+      child_b = PriorEmployer.new(business_name: "Globex")
+      flow_record = EmploymentForm.new(prior_employers: [ child_a, child_b ])
+
+      loop_node = described_class.new(:prior_employer, association: :prior_employers)
+
+      expect(loop_node.records_for(flow_record)).to eq([ child_a, child_b ])
+    end
+  end
+
+  describe "#completed?" do
+    let(:loop_node) do
+      described_class.new(:prior_employer, association: :prior_employers, pages: [ business_name_page, role_page ])
+    end
+
+    it "is true when every child record is valid on every loop page" do
+      flow_record = EmploymentForm.new(prior_employers: [
+        PriorEmployer.new(business_name: "Acme", role: "Engineer"),
+        PriorEmployer.new(business_name: "Globex", role: "Manager")
+      ])
+
+      expect(loop_node).to be_completed(flow_record)
+    end
+
+    it "is false when any child record is invalid on any loop page" do
+      flow_record = EmploymentForm.new(prior_employers: [
+        PriorEmployer.new(business_name: "Acme", role: "Engineer"),
+        PriorEmployer.new(business_name: "Globex", role: nil)
+      ])
+
+      expect(loop_node).not_to be_completed(flow_record)
+    end
+
+    it "is true (vacuously) when the relation is empty" do
+      flow_record = EmploymentForm.new(prior_employers: [])
+
+      expect(loop_node).to be_completed(flow_record)
+    end
+  end
+
+  describe "#started?" do
+    let(:loop_node) do
+      described_class.new(:prior_employer, association: :prior_employers, pages: [ business_name_page, role_page ])
+    end
+
+    it "is true when any child record has any completed page" do
+      flow_record = EmploymentForm.new(prior_employers: [
+        PriorEmployer.new(business_name: "Acme")
+      ])
+
+      expect(loop_node).to be_started(flow_record)
+    end
+
+    it "is false when no child records exist" do
+      flow_record = EmploymentForm.new(prior_employers: [])
+
+      expect(loop_node).not_to be_started(flow_record)
+    end
+
+    it "is false when no child records have any completed page" do
+      flow_record = EmploymentForm.new(prior_employers: [
+        PriorEmployer.new
+      ])
+
+      expect(loop_node).not_to be_started(flow_record)
+    end
+  end
+end

--- a/spec/models/strata/flows/question_page_spec.rb
+++ b/spec/models/strata/flows/question_page_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Strata::Flows::QuestionPage do
   end
 
   describe "with an enclosing loop" do
-    let(:loop_node) { Strata::Flows::Loop.new(:prior_employer, association: :prior_employers) }
+    let(:loop_node) { Strata::Flows::Loop.new(:prior_employer, association: :sample_employment_details) }
     let(:page) { described_class.new("business_name", loop: loop_node) }
 
     it "is marked as in a loop" do
@@ -89,6 +89,19 @@ RSpec.describe Strata::Flows::QuestionPage do
           .to eq("/sample_application_forms/1/sample_employment_details/2/update_prior_employer_business_name")
         expect(page).to have_received(:update_prior_employer_business_name_sample_application_form_sample_employment_detail_path)
           .with(flow_record, child_record)
+      end
+
+      it "builds the helper name from the singularized association name (not the child class name)" do
+        # Capture the symbol passed to `send` to verify we route through association.singularize.
+        captured_method = nil
+        allow(page).to receive(:send).and_wrap_original do |original, method_name, *args|
+          captured_method = method_name
+          "/stubbed"
+        end
+
+        page.edit_path(flow_record, child_record)
+
+        expect(captured_method.to_s).to eq("edit_prior_employer_business_name_sample_application_form_sample_employment_detail_path")
       end
     end
 

--- a/spec/models/strata/flows/question_page_spec.rb
+++ b/spec/models/strata/flows/question_page_spec.rb
@@ -40,6 +40,94 @@ RSpec.describe Strata::Flows::QuestionPage do
       expect(page.edit_pathname).to eq("edit_first_name")
       expect(page.update_pathname).to eq("update_first_name")
     end
+
+    it "is not in a loop" do
+      expect(page).not_to be_in_loop
+    end
+  end
+
+  describe "with an enclosing loop" do
+    let(:loop_node) { Strata::Flows::Loop.new(:prior_employer, association: :prior_employers) }
+    let(:page) { described_class.new("business_name", loop: loop_node) }
+
+    it "is marked as in a loop" do
+      expect(page).to be_in_loop
+      expect(page.loop).to eq(loop_node)
+    end
+
+    it "namespaces edit_pathname and update_pathname by the loop name" do
+      expect(page.edit_pathname).to eq("edit_prior_employer_business_name")
+      expect(page.update_pathname).to eq("update_prior_employer_business_name")
+    end
+
+    context "with stubbed parent and child classes" do
+      before do
+        parent_class = Class.new { def self.name = "SampleApplicationForm" }
+        child_class = Class.new { def self.name = "SampleEmploymentDetail" }
+        stub_const("SampleApplicationForm", parent_class)
+        stub_const("SampleEmploymentDetail", child_class)
+      end
+
+      let(:flow_record) { SampleApplicationForm.new }
+      let(:child_record) { SampleEmploymentDetail.new }
+
+      it "uses the nested route helper for edit_path, passing parent and child" do
+        allow(page).to receive(:edit_prior_employer_business_name_sample_application_form_sample_employment_detail_path)
+          .and_return("/sample_application_forms/1/sample_employment_details/2/edit_prior_employer_business_name")
+
+        expect(page.edit_path(flow_record, child_record))
+          .to eq("/sample_application_forms/1/sample_employment_details/2/edit_prior_employer_business_name")
+        expect(page).to have_received(:edit_prior_employer_business_name_sample_application_form_sample_employment_detail_path)
+          .with(flow_record, child_record)
+      end
+
+      it "uses the nested route helper for update_path, passing parent and child" do
+        allow(page).to receive(:update_prior_employer_business_name_sample_application_form_sample_employment_detail_path)
+          .and_return("/sample_application_forms/1/sample_employment_details/2/update_prior_employer_business_name")
+
+        expect(page.update_path(flow_record, child_record))
+          .to eq("/sample_application_forms/1/sample_employment_details/2/update_prior_employer_business_name")
+        expect(page).to have_received(:update_prior_employer_business_name_sample_application_form_sample_employment_detail_path)
+          .with(flow_record, child_record)
+      end
+    end
+
+    it "evaluates needed?/completed? against the loop record, not the flow record" do
+      child_class = Class.new do
+        include ActiveModel::Model
+        include ActiveModel::Attributes
+        attribute :business_name, :string
+        validates :business_name, presence: true, on: :business_name
+      end
+      stub_const("PriorEmployer", child_class)
+
+      child_record = PriorEmployer.new
+      expect(page).not_to be_completed(child_record)
+
+      child_record.business_name = "Acme"
+      expect(page).to be_completed(child_record)
+    end
+
+    describe "with conditional if" do
+      let(:page) do
+        described_class.new("role", loop: loop_node, if: ->(loop_record) { loop_record.business_name.present? })
+      end
+
+      it "evaluates the predicate against the loop record" do
+        child_class = Class.new do
+          include ActiveModel::Model
+          include ActiveModel::Attributes
+          attribute :business_name, :string
+        end
+        stub_const("PriorEmployer", child_class)
+
+        empty_child = PriorEmployer.new
+        filled_child = PriorEmployer.new(business_name: "Acme")
+
+        expect(page).not_to be_needed(empty_child)
+        expect(page).to be_needed(filled_child)
+      end
+    end
   end
 
   describe "with conditional if" do

--- a/spec/models/strata/flows/task_evaluator_spec.rb
+++ b/spec/models/strata/flows/task_evaluator_spec.rb
@@ -91,4 +91,175 @@ RSpec.describe Strata::Flows::TaskEvaluator do
       end
     end
   end
+
+  describe "traversal across a loop" do
+    let(:outer_before) { Strata::Flows::QuestionPage.new(:employer_name) }
+    let(:loop_business_name) { Strata::Flows::QuestionPage.new(:business_name) }
+    let(:loop_role) { Strata::Flows::QuestionPage.new(:role) }
+    let(:loop_node) do
+      Strata::Flows::Loop.new(
+        :prior_employer,
+        association: :prior_employers,
+        pages: [ loop_business_name, loop_role ]
+      )
+    end
+    let(:outer_after) { Strata::Flows::QuestionPage.new(:years_employed) }
+    let(:task) do
+      Strata::Flows::Task.new(:employment, pages: [ outer_before, loop_node, outer_after ])
+    end
+    let(:child_a) { PriorEmployer.new(business_name: "Acme") }
+    let(:child_b) { PriorEmployer.new(business_name: "Globex") }
+    let(:flow_record) { EmploymentForm.new(prior_employers: [ child_a, child_b ]) }
+
+    before do
+      child_class = Class.new do
+        include ActiveModel::Model
+        include ActiveModel::Attributes
+        attribute :business_name, :string
+        attribute :role, :string
+      end
+
+      parent_class = Class.new do
+        include ActiveModel::Model
+        attr_accessor :prior_employers, :employer_name, :years_employed
+
+        def initialize(prior_employers: [], employer_name: nil, years_employed: nil)
+          @prior_employers = prior_employers
+          @employer_name = employer_name
+          @years_employed = years_employed
+        end
+      end
+
+      stub_const("PriorEmployer", child_class)
+      stub_const("EmploymentForm", parent_class)
+
+      # Back-reference loop pages to their loop (implementation does this via the
+      # DSL when constructing the Loop; here we wire it manually).
+      [ loop_business_name, loop_role ].each { |p| p.loop = loop_node }
+    end
+
+    describe "#next_path on the outer page before the loop" do
+      it "enters the loop at the first loop page for the first child record" do
+        allow(loop_business_name).to receive(:edit_path).with(flow_record, child_a).and_return("/loop/a/business_name")
+        cursor = described_class.new(task, flow_record, 0)
+
+        expect(cursor.next_path).to eq("/loop/a/business_name")
+      end
+
+      it "skips the loop and continues to the next outer page when the relation is empty" do
+        empty_flow_record = EmploymentForm.new(prior_employers: [])
+        allow(outer_after).to receive(:edit_path).with(empty_flow_record).and_return("/years_employed")
+        cursor = described_class.new(task, empty_flow_record, 0)
+
+        expect(cursor.next_path).to eq("/years_employed")
+      end
+    end
+
+    describe "#next_path inside the loop (not the last page)" do
+      it "advances to the next loop page for the same child record" do
+        allow(loop_role).to receive(:edit_path).with(flow_record, child_a).and_return("/loop/a/role")
+        cursor = described_class.new(task, flow_record, 1, loop_record: child_a, loop_page_idx: 0)
+
+        expect(cursor.next_path).to eq("/loop/a/role")
+      end
+    end
+
+    describe "#next_path on the last loop page" do
+      it "advances to the first loop page for the next child record" do
+        allow(loop_business_name).to receive(:edit_path).with(flow_record, child_b).and_return("/loop/b/business_name")
+        cursor = described_class.new(task, flow_record, 1, loop_record: child_a, loop_page_idx: 1)
+
+        expect(cursor.next_path).to eq("/loop/b/business_name")
+      end
+
+      it "exits the loop to the next outer page when on the last child's last loop page" do
+        allow(outer_after).to receive(:edit_path).with(flow_record).and_return("/years_employed")
+        cursor = described_class.new(task, flow_record, 1, loop_record: child_b, loop_page_idx: 1)
+
+        expect(cursor.next_path).to eq("/years_employed")
+      end
+
+      it "returns nil when there is no outer page after the loop and we are on the last child's last loop page" do
+        task_without_after = Strata::Flows::Task.new(:employment, pages: [ outer_before, loop_node ])
+        cursor = described_class.new(task_without_after, flow_record, 1, loop_record: child_b, loop_page_idx: 1)
+
+        expect(cursor.next_path).to be_nil
+      end
+    end
+
+    describe "#next_path with if: predicates inside the loop" do
+      let(:loop_role) do
+        Strata::Flows::QuestionPage.new(:role, if: ->(child) { child.business_name == "Globex" })
+      end
+
+      it "skips a loop page for a child whose predicate is false, advancing to the next child" do
+        # child_a.business_name == "Acme", so :role is skipped for child_a; advance to child_b's first page
+        allow(loop_business_name).to receive(:edit_path).with(flow_record, child_b).and_return("/loop/b/business_name")
+        cursor = described_class.new(task, flow_record, 1, loop_record: child_a, loop_page_idx: 0)
+
+        expect(cursor.next_path).to eq("/loop/b/business_name")
+      end
+    end
+
+    describe "#prev_path inside the loop" do
+      it "returns the previous loop page for the same child record" do
+        allow(loop_business_name).to receive(:edit_path).with(flow_record, child_a).and_return("/loop/a/business_name")
+        cursor = described_class.new(task, flow_record, 1, loop_record: child_a, loop_page_idx: 1)
+
+        expect(cursor.prev_path).to eq("/loop/a/business_name")
+      end
+
+      it "wraps back to the previous child's last loop page when on the first loop page of a non-first child" do
+        allow(loop_role).to receive(:edit_path).with(flow_record, child_a).and_return("/loop/a/role")
+        cursor = described_class.new(task, flow_record, 1, loop_record: child_b, loop_page_idx: 0)
+
+        expect(cursor.prev_path).to eq("/loop/a/role")
+      end
+
+      it "exits the loop backwards to the outer page when on the first child's first loop page" do
+        allow(outer_before).to receive(:edit_path).with(flow_record).and_return("/employer_name")
+        cursor = described_class.new(task, flow_record, 1, loop_record: child_a, loop_page_idx: 0)
+
+        expect(cursor.prev_path).to eq("/employer_name")
+      end
+    end
+
+    describe "#prev_path on the outer page after the loop" do
+      it "enters the loop backwards at the last loop page of the last child record" do
+        allow(loop_role).to receive(:edit_path).with(flow_record, child_b).and_return("/loop/b/role")
+        cursor = described_class.new(task, flow_record, 2)
+
+        expect(cursor.prev_path).to eq("/loop/b/role")
+      end
+
+      it "skips an empty loop and returns the outer page before it" do
+        empty_flow_record = EmploymentForm.new(prior_employers: [])
+        allow(outer_before).to receive(:edit_path).with(empty_flow_record).and_return("/employer_name")
+        cursor = described_class.new(task, empty_flow_record, 2)
+
+        expect(cursor.prev_path).to eq("/employer_name")
+      end
+    end
+
+    describe "#current_page" do
+      it "returns the loop page when the cursor is inside a loop" do
+        cursor = described_class.new(task, flow_record, 1, loop_record: child_a, loop_page_idx: 1)
+        expect(cursor.current_page).to eq(loop_role)
+      end
+
+      it "returns the outer page when the cursor is outside a loop" do
+        cursor = described_class.new(task, flow_record, 0)
+        expect(cursor.current_page).to eq(outer_before)
+      end
+    end
+
+    describe "#update_path" do
+      it "returns the namespaced update_path with parent and child for a loop page" do
+        allow(loop_business_name).to receive(:update_path).with(flow_record, child_a).and_return("/loop/a/update_business_name")
+        cursor = described_class.new(task, flow_record, 1, loop_record: child_a, loop_page_idx: 0)
+
+        expect(cursor.update_path).to eq("/loop/a/update_business_name")
+      end
+    end
+  end
 end

--- a/spec/models/strata/flows/task_evaluator_spec.rb
+++ b/spec/models/strata/flows/task_evaluator_spec.rb
@@ -187,6 +187,32 @@ RSpec.describe Strata::Flows::TaskEvaluator do
       end
     end
 
+    describe "#next_path with a scoped loop" do
+      let(:loop_node) do
+        Strata::Flows::Loop.new(
+          :prior_employer,
+          association: :prior_employers,
+          pages: [ loop_business_name, loop_role ],
+          scope: ->(records) { records.select { |r| r.business_name == "Acme" } }
+        )
+      end
+
+      it "treats out-of-scope records as if they don't exist when advancing past the loop" do
+        # child_b is filtered out by the scope; cursor at child_a's last page exits the loop.
+        allow(outer_after).to receive(:edit_path).with(flow_record).and_return("/years_employed")
+        cursor = described_class.new(task, flow_record, 1, loop_record: child_a, loop_page_idx: 1)
+
+        expect(cursor.next_path).to eq("/years_employed")
+      end
+
+      it "enters the loop at the first in-scope record from the outer page" do
+        allow(loop_business_name).to receive(:edit_path).with(flow_record, child_a).and_return("/loop/a/business_name")
+        cursor = described_class.new(task, flow_record, 0)
+
+        expect(cursor.next_path).to eq("/loop/a/business_name")
+      end
+    end
+
     describe "#next_path with if: predicates inside the loop" do
       let(:loop_role) do
         Strata::Flows::QuestionPage.new(:role, if: ->(child) { child.business_name == "Globex" })

--- a/spec/models/strata/flows/task_spec.rb
+++ b/spec/models/strata/flows/task_spec.rb
@@ -61,6 +61,89 @@ RSpec.describe Strata::Flows::Task do
     end
   end
 
+  describe "a task containing a loop" do
+    before do
+      child_class = Class.new do
+        include ActiveModel::Model
+        include ActiveModel::Attributes
+        attribute :business_name, :string
+        attribute :role, :string
+        validates :business_name, presence: true, on: :business_name
+        validates :role, presence: true, on: :role
+      end
+
+      parent_class = Class.new do
+        include ActiveModel::Model
+        attr_accessor :prior_employers, :first_name
+
+        def initialize(prior_employers: [], first_name: nil)
+          @prior_employers = prior_employers
+          @first_name = first_name
+        end
+      end
+
+      stub_const("PriorEmployer", child_class)
+      stub_const("EmploymentForm", parent_class)
+    end
+
+    let(:outer_page) { Strata::Flows::QuestionPage.new(:first_name) }
+    let(:loop_node) do
+      Strata::Flows::Loop.new(
+        :prior_employer,
+        association: :prior_employers,
+        pages: [
+          Strata::Flows::QuestionPage.new(:business_name),
+          Strata::Flows::QuestionPage.new(:role)
+        ]
+      )
+    end
+    let(:task) { described_class.new(:employment, pages: [ outer_page, loop_node ]) }
+
+    it "is started when the outer page is started" do
+      flow_record = EmploymentForm.new(first_name: "Mary", prior_employers: [])
+
+      expect(task).to be_started(flow_record)
+    end
+
+    it "is started when any child record has any completed loop page" do
+      flow_record = EmploymentForm.new(
+        prior_employers: [ PriorEmployer.new(business_name: "Acme") ]
+      )
+
+      expect(task).to be_started(flow_record)
+    end
+
+    it "is completed when the outer page and every child loop page are valid" do
+      flow_record = EmploymentForm.new(
+        first_name: "Mary",
+        prior_employers: [
+          PriorEmployer.new(business_name: "Acme", role: "Engineer"),
+          PriorEmployer.new(business_name: "Globex", role: "Manager")
+        ]
+      )
+
+      expect(task).to be_completed(flow_record)
+    end
+
+    it "is not completed when a child record fails a loop page" do
+      flow_record = EmploymentForm.new(
+        first_name: "Mary",
+        prior_employers: [
+          PriorEmployer.new(business_name: "Acme", role: "Engineer"),
+          PriorEmployer.new(business_name: "Globex")
+        ]
+      )
+
+      expect(task).not_to be_completed(flow_record)
+    end
+
+    it "is completed when the loop relation is empty and the outer page is valid" do
+      flow_record = EmploymentForm.new(first_name: "Mary", prior_employers: [])
+
+      expect(task).to be_completed(flow_record)
+    end
+  end
+
   describe "#dependencies_met?" do
     let(:complete_task) { described_class.new(:personal_info) }
     let(:incomplete_task) { described_class.new(:contact_info) }


### PR DESCRIPTION
## Changes

- Enables looping functionality for a has_many association
- Adds a `mount_flow_routes` helper
- Adds a `flow_record_id` helper

### Breaking Changes

- The optional `on_flow_record_invalid` method must accept a single parameter: `target_record`

## Context

This PR allows forms to insert loops that iterate over a has_many collection. For now, this _only_ supports looping over existing records and assumes that the records are created outside of the loop.

```rb
task :prior_employment do
  loop :prior_employers do
    question_page :business_name
    question_page :role
  end
end
```

Looping pages create nested routes, e.g.

```
/leave_application_forms/:leave_application_id/employment_details/:id/edit
```

## Testing

- Unit testing
- Updated the sample application
- Tested in downstream starter kit application
