### PR TITLE
Replace old breadcrumbs partial usages with BreadcrumbsComponent

### DIFF
--- a/app/views/strata/cases/show.html.erb
+++ b/app/views/strata/cases/show.html.erb
@@ -23,6 +23,7 @@
       text: kase.id
     }
   ]
+  breadcrumbs = breadcrumbs.map { |bc| bc.transform_keys { |k| k == :link ? :href : k } }
 %>
 <%= render Strata::US::BreadcrumbsComponent.new do |bc| %>
   <% bc.with_items(breadcrumbs) %>

--- a/app/views/strata/cases/show.html.erb
+++ b/app/views/strata/cases/show.html.erb
@@ -17,14 +17,16 @@
   breadcrumbs = local_assigns[:breadcrumbs] || [
     {
       text: "Cases",
-      link: polymorphic_path(model_class)
+      href: polymorphic_path(model_class)
     },
     {
       text: kase.id
     }
   ]
 %>
-<%= render partial: "strata/shared/breadcrumbs", locals: { breadcrumbs: } %>
+<%= render Strata::US::BreadcrumbsComponent.new do |bc| %>
+  <% bc.with_items(breadcrumbs) %>
+<% end %>
 
 <h1 class="usa-heading-xl">Case ID: <%= kase.id %></h1>
 <%= yield :case_summary %>

--- a/app/views/strata/cases/show.html.erb
+++ b/app/views/strata/cases/show.html.erb
@@ -23,6 +23,8 @@
       text: kase.id
     }
   ]
+  # Translate the legacy `link:` key to `href:` so downstream callers overriding
+  # `breadcrumbs` with the pre-component hash shape still render clickable links.
   breadcrumbs = breadcrumbs.map { |bc| bc.transform_keys { |k| k == :link ? :href : k } }
 %>
 <%= render Strata::US::BreadcrumbsComponent.new do |bc| %>

--- a/app/views/strata/shared/_breadcrumbs.html.erb
+++ b/app/views/strata/shared/_breadcrumbs.html.erb
@@ -1,3 +1,5 @@
+<%# Translate the legacy `link:` key to `href:` so downstream callers passing the
+    pre-component hash shape still render clickable links. %>
 <%
   breadcrumbs = breadcrumbs.map { |bc| bc.transform_keys { |k| k == :link ? :href : k } }
 %>

--- a/app/views/strata/shared/_breadcrumbs.html.erb
+++ b/app/views/strata/shared/_breadcrumbs.html.erb
@@ -1,18 +1,3 @@
-<% if content_for?(:breadcrumbs) %>
-  <%= yield :breadcrumbs %>
-<% else %>
-  <nav class="usa-breadcrumb" aria-label="Breadcrumbs">
-    <ol class="usa-breadcrumb__list">
-      <% breadcrumbs[0...-1].each do |breadcrumb| %>
-        <li class="usa-breadcrumb__list-item">
-          <%= link_to breadcrumb[:text], breadcrumb[:link], class: "usa-breadcrumb__link" %>
-        </li>
-      <% end %>
-      <% if breadcrumbs.last %>
-        <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
-          <span><%= breadcrumbs.last[:text] %></span>
-        </li>
-      <% end %>
-    </ol>
-  </nav>
+<%= render Strata::US::BreadcrumbsComponent.new do |bc| %>
+  <% bc.with_items(breadcrumbs) %>
 <% end %>

--- a/app/views/strata/shared/_breadcrumbs.html.erb
+++ b/app/views/strata/shared/_breadcrumbs.html.erb
@@ -1,3 +1,6 @@
+<%
+  breadcrumbs = breadcrumbs.map { |bc| bc.transform_keys { |k| k == :link ? :href : k } }
+%>
 <%= render Strata::US::BreadcrumbsComponent.new do |bc| %>
   <% bc.with_items(breadcrumbs) %>
 <% end %>

--- a/app/views/strata/tasks/show.html.erb
+++ b/app/views/strata/tasks/show.html.erb
@@ -43,6 +43,7 @@
       text: t("tasks.types.#{task.type.underscore}")
     }
   ]
+  breadcrumbs = breadcrumbs.map { |bc| bc.transform_keys { |k| k == :link ? :href : k } }
 %>
 <%= render Strata::US::BreadcrumbsComponent.new do |bc| %>
   <% bc.with_items(breadcrumbs) %>

--- a/app/views/strata/tasks/show.html.erb
+++ b/app/views/strata/tasks/show.html.erb
@@ -33,18 +33,20 @@
   breadcrumbs = local_assigns[:breadcrumbs] || [
     {
       text: t("strata.tasks.breadcrumbs.home"),
-      link: "/"
+      href: "/"
     },
     {
       text: t("strata.tasks.breadcrumbs.tasks"),
-      link: url_for(only_path: true, action: :index)
+      href: url_for(only_path: true, action: :index)
     },
     {
       text: t("tasks.types.#{task.type.underscore}")
     }
   ]
 %>
-<%= render partial: "strata/shared/breadcrumbs", locals: { breadcrumbs: } %>
+<%= render Strata::US::BreadcrumbsComponent.new do |bc| %>
+  <% bc.with_items(breadcrumbs) %>
+<% end %>
 <h1 class="section-heading-h1"><%= t("tasks.types.#{task.type.underscore}") %></h1>
 <%
   task_info = local_assigns[:task_info] || [

--- a/app/views/strata/tasks/show.html.erb
+++ b/app/views/strata/tasks/show.html.erb
@@ -43,6 +43,8 @@
       text: t("tasks.types.#{task.type.underscore}")
     }
   ]
+  # Translate the legacy `link:` key to `href:` so downstream callers overriding
+  # `breadcrumbs` with the pre-component hash shape still render clickable links.
   breadcrumbs = breadcrumbs.map { |bc| bc.transform_keys { |k| k == :link ? :href : k } }
 %>
 <%= render Strata::US::BreadcrumbsComponent.new do |bc| %>

--- a/spec/views/strata/shared/_breadcrumbs.html.erb_spec.rb
+++ b/spec/views/strata/shared/_breadcrumbs.html.erb_spec.rb
@@ -59,6 +59,26 @@ RSpec.describe "strata/shared/_breadcrumbs.html.erb", type: :view do
     end
   end
 
+  context "with breadcrumbs using the legacy link: key" do
+    let(:breadcrumbs) {
+      [
+        { text: "Home", link: "/" },
+        { text: "Cases", link: "/cases" },
+        { text: "Case #12345" }
+      ]
+    }
+
+    it "still renders the URLs as clickable links" do
+      expect(rendered).to have_selector('a.usa-breadcrumb__link[href="/"]', text: "Home")
+      expect(rendered).to have_selector('a.usa-breadcrumb__link[href="/cases"]', text: "Cases")
+    end
+
+    it "marks the last item as the current page without a link" do
+      expect(rendered).to have_selector('li.usa-current span', text: "Case #12345")
+      expect(rendered).not_to have_selector('li.usa-current a')
+    end
+  end
+
   context "with breadcrumbs containing special characters" do
     let(:breadcrumbs) {
       [

--- a/spec/views/strata/shared/_breadcrumbs.html.erb_spec.rb
+++ b/spec/views/strata/shared/_breadcrumbs.html.erb_spec.rb
@@ -3,93 +3,75 @@
 require 'rails_helper'
 
 RSpec.describe "strata/shared/_breadcrumbs.html.erb", type: :view do
-  describe "when custom breadcrumbs are provided" do
-    before do
-      view.content_for(:breadcrumbs) do
-        '<nav>Custom breadcrumbs</nav>'
-      end
-      render partial: "strata/shared/breadcrumbs"
-    end
+  before do
+    render partial: "strata/shared/breadcrumbs", locals: { breadcrumbs: breadcrumbs }
+  end
 
-    it "renders the custom breadcrumbs content" do
-      expect(rendered).to include('Custom breadcrumbs')
-    end
+  context "with a single breadcrumb" do
+    let(:breadcrumbs) { [ { text: "Dashboard" } ] }
 
-    it "does not render the default breadcrumb navigation" do
-      expect(rendered).not_to include('usa-breadcrumb')
+    it "renders a single breadcrumb without a link" do
+      expect(rendered).to have_selector('nav.usa-breadcrumb')
+      expect(rendered).to have_selector('ol.usa-breadcrumb__list')
+      expect(rendered).to have_selector('li.usa-breadcrumb__list-item.usa-current[aria-current="page"]')
+      expect(rendered).to have_selector('span', text: "Dashboard")
+      expect(rendered).not_to have_selector('a.usa-breadcrumb__link')
     end
   end
 
-  describe "when no custom breadcrumbs are provided" do
-    before do
-      render partial: "strata/shared/breadcrumbs", locals: { breadcrumbs: breadcrumbs }
+  context "with multiple breadcrumbs" do
+    let(:breadcrumbs) {
+      [
+        { text: "Home", href: "/" },
+        { text: "Cases", href: "/cases" },
+        { text: "Case #12345" }
+      ]
+    }
+
+    it "renders all breadcrumbs with proper structure" do
+      expect(rendered).to have_selector('nav.usa-breadcrumb')
+      expect(rendered).to have_selector('ol.usa-breadcrumb__list')
     end
 
-    context "with a single breadcrumb" do
-      let(:breadcrumbs) { [ { text: "Dashboard" } ] }
-
-      it "renders a single breadcrumb without a link" do
-        expect(rendered).to have_selector('nav.usa-breadcrumb[aria-label="Breadcrumbs"]')
-        expect(rendered).to have_selector('ol.usa-breadcrumb__list')
-        expect(rendered).to have_selector('li.usa-breadcrumb__list-item.usa-current[aria-current="page"]')
-        expect(rendered).to have_selector('span', text: "Dashboard")
-        expect(rendered).not_to have_selector('a.usa-breadcrumb__link')
-      end
+    it "renders clickable links for all but the last breadcrumb" do
+      expect(rendered).to have_selector('li.usa-breadcrumb__list-item a.usa-breadcrumb__link[href="/"]', text: "Home")
+      expect(rendered).to have_selector('li.usa-breadcrumb__list-item a.usa-breadcrumb__link[href="/cases"]', text: "Cases")
     end
 
-    context "with multiple breadcrumbs" do
-      let(:breadcrumbs) {
-        [
-          { text: "Home", link: "/" },
-          { text: "Cases", link: "/cases" },
-          { text: "Case #12345" }
-        ]
-      }
-
-      it "renders all breadcrumbs with proper structure" do
-        expect(rendered).to have_selector('nav.usa-breadcrumb[aria-label="Breadcrumbs"]')
-        expect(rendered).to have_selector('ol.usa-breadcrumb__list')
-      end
-
-      it "renders clickable links for all but the last breadcrumb" do
-        expect(rendered).to have_selector('li.usa-breadcrumb__list-item a.usa-breadcrumb__link[href="/"]', text: "Home")
-        expect(rendered).to have_selector('li.usa-breadcrumb__list-item a.usa-breadcrumb__link[href="/cases"]', text: "Cases")
-      end
-
-      it "renders the last breadcrumb as current page without a link" do
-        expect(rendered).to have_selector('li.usa-breadcrumb__list-item.usa-current[aria-current="page"]')
-        expect(rendered).to have_selector('li.usa-current span', text: "Case #12345")
-        expect(rendered).not_to have_selector('li.usa-current a')
-      end
-
-      it "has proper accessibility attributes" do
-        expect(rendered).to have_selector('nav[aria-label="Breadcrumbs"]')
-        expect(rendered).to have_selector('li[aria-current="page"]')
-      end
+    it "renders the last breadcrumb as current page without a link" do
+      expect(rendered).to have_selector('li.usa-breadcrumb__list-item.usa-current[aria-current="page"]')
+      expect(rendered).to have_selector('li.usa-current span', text: "Case #12345")
+      expect(rendered).not_to have_selector('li.usa-current a')
     end
 
-    context "with empty breadcrumbs array" do
-      let(:breadcrumbs) { [] }
-
-      it "raises an error when trying to access last element" do
-        expect { render partial: "strata/shared/breadcrumbs", locals: { breadcrumbs: breadcrumbs } }.not_to raise_error
-      end
+    it "has proper accessibility attributes" do
+      expect(rendered).to have_selector('nav[aria-label]')
+      expect(rendered).to have_selector('li[aria-current="page"]')
     end
+  end
 
-    context "with breadcrumbs containing special characters" do
-      let(:breadcrumbs) {
-        [
-          { text: "Home & Dashboard", link: "/" },
-          { text: "Cases > Applications", link: "/cases" },
-          { text: "Case #12345 (Active)" }
-        ]
-      }
+  context "with empty breadcrumbs array" do
+    let(:breadcrumbs) { [] }
 
-      it "properly escapes special characters in text" do
-        expect(rendered).to include("Home &amp; Dashboard")
-        expect(rendered).to include("Cases &gt; Applications")
-        expect(rendered).to include("Case #12345 (Active)")
-      end
+    it "renders the nav and empty list without raising" do
+      expect(rendered).to have_selector('ol.usa-breadcrumb__list')
+      expect(rendered).not_to have_selector('li')
+    end
+  end
+
+  context "with breadcrumbs containing special characters" do
+    let(:breadcrumbs) {
+      [
+        { text: "Home & Dashboard", href: "/" },
+        { text: "Cases > Applications", href: "/cases" },
+        { text: "Case #12345 (Active)" }
+      ]
+    }
+
+    it "properly escapes special characters in text" do
+      expect(rendered).to include("Home &amp; Dashboard")
+      expect(rendered).to include("Cases &gt; Applications")
+      expect(rendered).to include("Case #12345 (Active)")
     end
   end
 end


### PR DESCRIPTION
## Summary
- Render `Strata::US::BreadcrumbsComponent` directly from [cases/show.html.erb](app/views/strata/cases/show.html.erb) and [tasks/show.html.erb](app/views/strata/tasks/show.html.erb) instead of the legacy `strata/shared/breadcrumbs` partial.
- Rename the breadcrumb hash key from `link:` to `href:` in both show views to match the component's `with_items` API.
- Rewrite [_breadcrumbs.html.erb](app/views/strata/shared/_breadcrumbs.html.erb) as a thin shim that delegates to the component, so any downstream apps still rendering the partial keep working. Dropped the unused `content_for(:breadcrumbs)` escape hatch.
- Update the partial spec to cover the new shim contract (drops the `content_for` tests, renames fixture keys, relaxes the aria-label assertion since the component sources it from I18n — the literal is covered in the component spec).

## Test plan
- [x] `make lint` clean
- [x] `make test` — 1,322 examples, 0 failures
- [ ] Spot-check `cases/show` and `tasks/show` in the dummy app via `make start` and confirm breadcrumbs render

🤖 Generated with [Claude Code](https://claude.com/claude-code)