### PR TITLE
Add USWDS Button and ButtonGroup components

### DIFF
--- a/app/components/strata/us/button_component.html.erb
+++ b/app/components/strata/us/button_component.html.erb
@@ -1,0 +1,1 @@
+<%= content_tag element_tag, **element_attributes do %><%= content %><% end %>

--- a/app/components/strata/us/button_component.rb
+++ b/app/components/strata/us/button_component.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+module Strata
+  module US
+    # ButtonComponent renders a USWDS button as either a <button> or an <a>.
+    # Use the +href:+ keyword to switch from a button element to an anchor styled
+    # as a button.
+    #
+    # See https://designsystem.digital.gov/components/button/.
+    #
+    # For places where Rails owns the element rendering (e.g. +button_to+,
+    # +link_to+, +form.button+, +f.submit+), use the class-method helper
+    # +Strata::US::ButtonComponent.css_classes+ to produce a matching class
+    # string without going through the component.
+    #
+    # @example A primary button
+    #   <%= render Strata::US::ButtonComponent.new do %>
+    #     Save
+    #   <% end %>
+    #
+    # @example A secondary, big, link-styled button
+    #   <%= render Strata::US::ButtonComponent.new(href: edit_path, variant: :secondary, size: :big) do %>
+    #     Edit
+    #   <% end %>
+    #
+    # @example Class-string helper for button_to
+    #   <%= button_to "Delete", path, method: :delete,
+    #         class: Strata::US::ButtonComponent.css_classes(variant: :secondary) %>
+    class ButtonComponent < ViewComponent::Base
+      ALLOWED_VARIANTS = %i[default secondary accent_cool accent_warm base outline unstyled].freeze
+      ALLOWED_SIZES = %i[default big].freeze
+
+      VARIANT_MODIFIERS = {
+        default: nil,
+        secondary: "usa-button--secondary",
+        accent_cool: "usa-button--accent-cool",
+        accent_warm: "usa-button--accent-warm",
+        base: "usa-button--base",
+        outline: "usa-button--outline",
+        unstyled: "usa-button--unstyled"
+      }.freeze
+
+      def initialize(
+        variant: :default,
+        size: :default,
+        inverse: false,
+        type: :button,
+        href: nil,
+        disabled: false,
+        classes: nil,
+        **html_attributes
+      )
+        self.class.send(:validate_variant!, variant)
+        self.class.send(:validate_size!, size)
+
+        @variant = variant
+        @size = size
+        @inverse = inverse
+        @type = type
+        @href = href
+        @disabled = disabled
+        @classes = classes
+        @html_attributes = html_attributes
+      end
+
+      # Returns the USWDS class string for a button-styled element, without
+      # rendering the element itself. Use this for +button_to+, +link_to+,
+      # +form.button+, and other call sites where Rails owns the tag.
+      def self.css_classes(variant: :default, size: :default, inverse: false)
+        validate_variant!(variant)
+        validate_size!(size)
+
+        parts = [ "usa-button", VARIANT_MODIFIERS[variant] ]
+        parts << "usa-button--big" if size == :big
+        parts << "usa-button--inverse" if inverse
+        parts.compact.join(" ")
+      end
+
+      def element_tag
+        @href ? :a : :button
+      end
+
+      def element_attributes
+        attrs = @html_attributes.dup
+        attrs[:class] = combined_classes
+
+        if @href
+          attrs[:href] = @href
+          attrs[:"aria-disabled"] = "true" if @disabled
+        else
+          attrs[:type] = @type
+          attrs[:disabled] = true if @disabled
+        end
+
+        attrs
+      end
+
+      private
+
+      def combined_classes
+        base = self.class.css_classes(variant: @variant, size: @size, inverse: @inverse)
+        @classes.present? ? "#{base} #{@classes}" : base
+      end
+
+      def self.validate_variant!(variant)
+        return if ALLOWED_VARIANTS.include?(variant)
+
+        raise ArgumentError,
+          "Invalid variant: #{variant.inspect}. Must be one of #{ALLOWED_VARIANTS.inspect}"
+      end
+      private_class_method :validate_variant!
+
+      def self.validate_size!(size)
+        return if ALLOWED_SIZES.include?(size)
+
+        raise ArgumentError,
+          "Invalid size: #{size.inspect}. Must be one of #{ALLOWED_SIZES.inspect}"
+      end
+      private_class_method :validate_size!
+    end
+  end
+end

--- a/app/components/strata/us/button_group_component.html.erb
+++ b/app/components/strata/us/button_group_component.html.erb
@@ -1,0 +1,5 @@
+<%= content_tag :ul, **list_attributes do %>
+  <% items.each do |item| %>
+    <%= item %>
+  <% end %>
+<% end %>

--- a/app/components/strata/us/button_group_component.rb
+++ b/app/components/strata/us/button_group_component.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Strata
+  module US
+    # ButtonGroupComponent renders a USWDS button group: a <ul class="usa-button-group">
+    # whose children are <li class="usa-button-group__item"> wrappers containing
+    # whatever button-styled element the caller chooses (a Strata::US::ButtonComponent,
+    # a link_to, an f.submit, etc.).
+    #
+    # See https://designsystem.digital.gov/components/button-group/.
+    #
+    # @example Default
+    #   <%= render Strata::US::ButtonGroupComponent.new do |group| %>
+    #     <% group.with_item do %>
+    #       <%= render Strata::US::ButtonComponent.new do %>Save<% end %>
+    #     <% end %>
+    #     <% group.with_item do %>
+    #       <%= link_to "Cancel", cancel_path,
+    #             class: Strata::US::ButtonComponent.css_classes(variant: :outline) %>
+    #     <% end %>
+    #   <% end %>
+    #
+    # @example Segmented
+    #   <%= render Strata::US::ButtonGroupComponent.new(segmented: true) do |group| %>
+    #     <% group.with_item { ... } %>
+    #     <% group.with_item { ... } %>
+    #   <% end %>
+    class ButtonGroupComponent < ViewComponent::Base
+      renders_many :items, "Strata::US::ButtonGroupComponent::ItemComponent"
+
+      def initialize(segmented: false, classes: nil, **html_attributes)
+        @segmented = segmented
+        @classes = classes
+        @html_attributes = html_attributes
+      end
+
+      def wrapper_classes
+        class_names(
+          "usa-button-group",
+          { "usa-button-group--segmented" => @segmented },
+          @classes
+        )
+      end
+
+      def list_attributes
+        attrs = @html_attributes.dup
+        attrs[:class] = wrapper_classes
+        attrs
+      end
+
+      # ItemComponent renders one entry as an <li class="usa-button-group__item">.
+      class ItemComponent < ViewComponent::Base
+        def initialize(classes: nil, **html_attributes)
+          @classes = classes
+          @html_attributes = html_attributes
+        end
+
+        def call
+          attrs = @html_attributes.dup
+          attrs[:class] = class_names("usa-button-group__item", @classes)
+
+          content_tag(:li, content, **attrs)
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/strata/form_builder.rb
+++ b/app/helpers/strata/form_builder.rb
@@ -154,12 +154,22 @@ module Strata
       form_group(attribute) { content }
     end
 
+    # Renders the submit input with USWDS button styling.
+    #
+    # @option options [Symbol] :variant Visual variant
+    #   (+:default+, +:secondary+, +:accent_cool+, +:accent_warm+, +:base+,
+    #   +:outline+, +:unstyled+). Defaults to +:default+ (primary).
+    # @option options [Boolean] :big When true, applies the +usa-button--big+
+    #   modifier along with extra vertical margin.
+    # @param [Object, nil] value
     def submit(value = nil, options = {})
-      append_to_option(options, :class, " usa-button")
+      variant = options.delete(:variant) || :default
+      big = options.delete(:big)
+      size = big ? :big : :default
 
-      if options[:big]
-        append_to_option(options, :class, " usa-button--big margin-y-6")
-      end
+      button_classes = Strata::US::ButtonComponent.css_classes(variant: variant, size: size)
+      append_to_option(options, :class, " #{button_classes}")
+      append_to_option(options, :class, " margin-y-6") if big
 
       super(value, options)
     end

--- a/app/previews/strata/us/button_component_preview.rb
+++ b/app/previews/strata/us/button_component_preview.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Strata
+  module US
+    # ButtonComponentPreview provides preview examples for the Strata::US::ButtonComponent.
+    class ButtonComponentPreview < Lookbook::Preview
+      layout "strata/component_preview"
+
+      # @label Default (primary)
+      def default
+        render Strata::US::ButtonComponent.new do
+          "Default"
+        end
+      end
+
+      # @label Secondary
+      def secondary
+        render Strata::US::ButtonComponent.new(variant: :secondary) do
+          "Secondary"
+        end
+      end
+
+      # @label Accent cool
+      def accent_cool
+        render Strata::US::ButtonComponent.new(variant: :accent_cool) do
+          "Accent cool"
+        end
+      end
+
+      # @label Accent warm
+      def accent_warm
+        render Strata::US::ButtonComponent.new(variant: :accent_warm) do
+          "Accent warm"
+        end
+      end
+
+      # @label Base
+      def base
+        render Strata::US::ButtonComponent.new(variant: :base) do
+          "Base"
+        end
+      end
+
+      # @label Outline
+      def outline
+        render Strata::US::ButtonComponent.new(variant: :outline) do
+          "Outline"
+        end
+      end
+
+      # @label Unstyled
+      def unstyled
+        render Strata::US::ButtonComponent.new(variant: :unstyled) do
+          "Unstyled"
+        end
+      end
+
+      # @label Big size
+      def big
+        render Strata::US::ButtonComponent.new(size: :big) do
+          "Big primary"
+        end
+      end
+
+      # @label Link styled as button
+      def as_link
+        render Strata::US::ButtonComponent.new(href: "#", variant: :outline) do
+          "Outline link"
+        end
+      end
+
+      # @label Submit-typed button
+      def submit_type
+        render Strata::US::ButtonComponent.new(type: :submit) do
+          "Submit"
+        end
+      end
+
+      # @label Disabled button
+      def disabled
+        render Strata::US::ButtonComponent.new(disabled: true) do
+          "Disabled"
+        end
+      end
+
+      # @label Disabled link
+      def disabled_link
+        render Strata::US::ButtonComponent.new(href: "#", disabled: true) do
+          "Disabled link"
+        end
+      end
+    end
+  end
+end

--- a/app/previews/strata/us/button_group_component_preview.rb
+++ b/app/previews/strata/us/button_group_component_preview.rb
@@ -7,31 +7,12 @@ module Strata
       layout "strata/component_preview"
 
       # @label Default
-      def default
-        render Strata::US::ButtonGroupComponent.new do |group|
-          group.with_item do
-            %(<button class="#{Strata::US::ButtonComponent.css_classes}">Save</button>).html_safe
-          end
-          group.with_item do
-            %(<button class="#{Strata::US::ButtonComponent.css_classes(variant: :outline)}">Cancel</button>).html_safe
-          end
-        end
-      end
+      # Renders via the sibling `default.html.erb` template — nested `render` calls don't work inside slot blocks in a Lookbook preview method.
+      def default; end
 
       # @label Segmented
-      def segmented
-        render Strata::US::ButtonGroupComponent.new(segmented: true) do |group|
-          group.with_item do
-            %(<button class="#{Strata::US::ButtonComponent.css_classes}">Map</button>).html_safe
-          end
-          group.with_item do
-            %(<button class="#{Strata::US::ButtonComponent.css_classes}">Satellite</button>).html_safe
-          end
-          group.with_item do
-            %(<button class="#{Strata::US::ButtonComponent.css_classes}">Hybrid</button>).html_safe
-          end
-        end
-      end
+      # Renders via the sibling `segmented.html.erb` template — nested `render` calls don't work inside slot blocks in a Lookbook preview method.
+      def segmented; end
     end
   end
 end

--- a/app/previews/strata/us/button_group_component_preview.rb
+++ b/app/previews/strata/us/button_group_component_preview.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Strata
+  module US
+    # ButtonGroupComponentPreview provides preview examples for the Strata::US::ButtonGroupComponent.
+    class ButtonGroupComponentPreview < Lookbook::Preview
+      layout "strata/component_preview"
+
+      # @label Default
+      def default
+        render Strata::US::ButtonGroupComponent.new do |group|
+          group.with_item do
+            %(<button class="#{Strata::US::ButtonComponent.css_classes}">Save</button>).html_safe
+          end
+          group.with_item do
+            %(<button class="#{Strata::US::ButtonComponent.css_classes(variant: :outline)}">Cancel</button>).html_safe
+          end
+        end
+      end
+
+      # @label Segmented
+      def segmented
+        render Strata::US::ButtonGroupComponent.new(segmented: true) do |group|
+          group.with_item do
+            %(<button class="#{Strata::US::ButtonComponent.css_classes}">Map</button>).html_safe
+          end
+          group.with_item do
+            %(<button class="#{Strata::US::ButtonComponent.css_classes}">Satellite</button>).html_safe
+          end
+          group.with_item do
+            %(<button class="#{Strata::US::ButtonComponent.css_classes}">Hybrid</button>).html_safe
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/previews/strata/us/button_group_component_preview/default.html.erb
+++ b/app/previews/strata/us/button_group_component_preview/default.html.erb
@@ -1,0 +1,8 @@
+<%= render Strata::US::ButtonGroupComponent.new do |group| %>
+  <% group.with_item do %>
+    <%= render(Strata::US::ButtonComponent.new) { "Save" } %>
+  <% end %>
+  <% group.with_item do %>
+    <%= render(Strata::US::ButtonComponent.new(variant: :outline)) { "Cancel" } %>
+  <% end %>
+<% end %>

--- a/app/previews/strata/us/button_group_component_preview/segmented.html.erb
+++ b/app/previews/strata/us/button_group_component_preview/segmented.html.erb
@@ -1,0 +1,11 @@
+<%= render Strata::US::ButtonGroupComponent.new(segmented: true) do |group| %>
+  <% group.with_item do %>
+    <%= render(Strata::US::ButtonComponent.new) { "Map" } %>
+  <% end %>
+  <% group.with_item do %>
+    <%= render(Strata::US::ButtonComponent.new) { "Satellite" } %>
+  <% end %>
+  <% group.with_item do %>
+    <%= render(Strata::US::ButtonComponent.new) { "Hybrid" } %>
+  <% end %>
+<% end %>

--- a/docs/uswds-components.md
+++ b/docs/uswds-components.md
@@ -17,10 +17,12 @@ Every component accepts a `classes:` keyword for additional CSS classes and forw
 1. [Accordion](#accordion)
 2. [Alert](#alert)
 3. [Breadcrumbs](#breadcrumbs)
-4. [Card](#card)
-5. [Card Group](#card-group)
-6. [List](#list)
-7. [Table](#table)
+4. [Button](#button)
+5. [Button Group](#button-group)
+6. [Card](#card)
+7. [Card Group](#card-group)
+8. [List](#list)
+9. [Table](#table)
 
 ---
 
@@ -121,6 +123,94 @@ Any other keyword arguments are forwarded as HTML attributes on the `<nav>`.
        { text: "Cases", href: cases_path },
        { text: "Case #12345" }
      ]) %>
+<% end %>
+```
+
+---
+
+## Button
+
+`Strata::US::ButtonComponent` — a USWDS-styled button rendered as either a `<button>` or an `<a>`. See [USWDS Button](https://designsystem.digital.gov/components/button/) and the [Lookbook preview](../app/previews/strata/us/button_component_preview.rb).
+
+Pass an `href:` to render an `<a class="usa-button">`; otherwise the component renders a `<button>`.
+
+**Options**
+
+- `variant:` — visual variant. One of `:default` (primary), `:secondary`, `:accent_cool`, `:accent_warm`, `:base`, `:outline`, `:unstyled`. Defaults to `:default`.
+- `size:` — `:default` or `:big`. Defaults to `:default`.
+- `inverse:` — render the inverse modifier for use on dark backgrounds. Defaults to `false`. USWDS recommends pairing this with `:outline` or `:unstyled`.
+- `type:` — `:button`, `:submit`, or `:reset`. Only applied to `<button>` elements (ignored when `href:` is set). Defaults to `:button`.
+- `href:` — when set, renders an `<a>` element instead of a `<button>`.
+- `disabled:` — when true, adds the `disabled` attribute on `<button>` or `aria-disabled="true"` on `<a>`. Defaults to `false`.
+- `classes:` — extra CSS classes appended to the root element.
+
+Any other keyword arguments are forwarded as HTML attributes on the rendered element.
+
+**Example**
+
+```erb
+<%= render Strata::US::ButtonComponent.new do %>
+  Save
+<% end %>
+
+<%= render Strata::US::ButtonComponent.new(href: edit_path, variant: :outline) do %>
+  Edit
+<% end %>
+
+<%= render Strata::US::ButtonComponent.new(variant: :secondary, size: :big, disabled: true) do %>
+  Delete
+<% end %>
+```
+
+### `Strata::US::ButtonComponent.css_classes`
+
+For call sites where Rails owns the element rendering — `button_to` (which generates its own `<form>`), `link_to`, `form.button`, `f.submit` — render the component directly isn't an option. Use the class-method helper to produce a matching USWDS class string:
+
+```erb
+<%= button_to "Delete", path, method: :delete,
+      class: Strata::US::ButtonComponent.css_classes(variant: :secondary) %>
+
+<%= link_to "Edit", edit_path,
+      class: Strata::US::ButtonComponent.css_classes(variant: :outline) %>
+```
+
+The Strata form builder's `f.submit` already delegates to this helper internally and accepts the same `:variant` and `:big` options:
+
+```erb
+<%= f.submit "Save draft", variant: :outline %>
+<%= f.submit "Apply", big: true %>
+```
+
+---
+
+## Button Group
+
+`Strata::US::ButtonGroupComponent` — a `<ul class="usa-button-group">` of related buttons, with the option to render the segmented variant. See [USWDS Button group](https://designsystem.digital.gov/components/button-group/) and the [Lookbook preview](../app/previews/strata/us/button_group_component_preview.rb).
+
+The component wraps each item in `<li class="usa-button-group__item">`. The `<li>` contents are up to the caller — typically a `Strata::US::ButtonComponent`, a `link_to`, or an `f.submit`.
+
+**Options**
+
+- `segmented:` — render the segmented variant (`usa-button-group--segmented`). Defaults to `false`.
+- `classes:` — extra CSS classes appended to the root `<ul>`.
+
+Any other keyword arguments are forwarded as HTML attributes on the `<ul>`.
+
+**Slots**
+
+- `with_item(classes: nil, **html_attributes) { ... }` — a single button-group entry. Extra keyword arguments are forwarded as HTML attributes on the `<li>`.
+
+**Example**
+
+```erb
+<%= render Strata::US::ButtonGroupComponent.new do |group| %>
+  <% group.with_item do %>
+    <%= render Strata::US::ButtonComponent.new do %>Save<% end %>
+  <% end %>
+  <% group.with_item do %>
+    <%= link_to "Cancel", cancel_path,
+          class: Strata::US::ButtonComponent.css_classes(variant: :outline) %>
+  <% end %>
 <% end %>
 ```
 

--- a/docs/uswds-components.md
+++ b/docs/uswds-components.md
@@ -164,7 +164,7 @@ Any other keyword arguments are forwarded as HTML attributes on the rendered ele
 
 ### `Strata::US::ButtonComponent.css_classes`
 
-For call sites where Rails owns the element rendering — `button_to` (which generates its own `<form>`), `link_to`, `form.button`, `f.submit` — render the component directly isn't an option. Use the class-method helper to produce a matching USWDS class string:
+For call sites where Rails owns the element rendering — `button_to` (which generates its own `<form>`), `link_to`, `form.button`, `f.submit` — rendering the component directly isn't an option. Use the class-method helper to produce a matching USWDS class string:
 
 ```erb
 <%= button_to "Delete", path, method: :delete,

--- a/spec/components/strata/us/button_component_spec.rb
+++ b/spec/components/strata/us/button_component_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Strata::US::ButtonComponent, type: :component do
+  describe "default render" do
+    it "renders a <button type='button'> with the base usa-button class" do
+      render_inline(described_class.new) { "Submit" }
+
+      expect(page).to have_css("button[type='button'].usa-button", text: "Submit")
+    end
+
+    it "does not add any variant modifier classes by default" do
+      render_inline(described_class.new) { "Submit" }
+
+      expect(page).not_to have_css(".usa-button--secondary")
+      expect(page).not_to have_css(".usa-button--accent-cool")
+      expect(page).not_to have_css(".usa-button--accent-warm")
+      expect(page).not_to have_css(".usa-button--base")
+      expect(page).not_to have_css(".usa-button--outline")
+      expect(page).not_to have_css(".usa-button--unstyled")
+      expect(page).not_to have_css(".usa-button--big")
+      expect(page).not_to have_css(".usa-button--inverse")
+    end
+
+    it "renders no disabled attribute by default" do
+      render_inline(described_class.new) { "Submit" }
+
+      expect(page).not_to have_css("button[disabled]")
+      expect(page).not_to have_css("button[aria-disabled]")
+    end
+  end
+
+  describe "variant" do
+    {
+      secondary: "usa-button--secondary",
+      accent_cool: "usa-button--accent-cool",
+      accent_warm: "usa-button--accent-warm",
+      base: "usa-button--base",
+      outline: "usa-button--outline",
+      unstyled: "usa-button--unstyled"
+    }.each do |variant, css_class|
+      it "adds #{css_class} for variant: #{variant.inspect}" do
+        render_inline(described_class.new(variant: variant)) { "Action" }
+        expect(page).to have_css("button.usa-button.#{css_class}", text: "Action")
+      end
+    end
+
+    it "raises ArgumentError when variant is not one of the allowed symbols" do
+      expect {
+        render_inline(described_class.new(variant: :nonsense)) { "Action" }
+      }.to raise_error(ArgumentError, /variant/)
+    end
+
+    it "raises ArgumentError when variant is nil" do
+      expect {
+        render_inline(described_class.new(variant: nil)) { "Action" }
+      }.to raise_error(ArgumentError, /variant/)
+    end
+  end
+
+  describe "size" do
+    it "omits the size modifier when size: :default" do
+      render_inline(described_class.new(size: :default)) { "Action" }
+      expect(page).not_to have_css(".usa-button--big")
+    end
+
+    it "adds usa-button--big when size: :big" do
+      render_inline(described_class.new(size: :big)) { "Action" }
+      expect(page).to have_css("button.usa-button.usa-button--big", text: "Action")
+    end
+
+    it "raises ArgumentError on an unknown size" do
+      expect {
+        render_inline(described_class.new(size: :huge)) { "Action" }
+      }.to raise_error(ArgumentError, /size/)
+    end
+  end
+
+  describe "inverse" do
+    it "omits usa-button--inverse by default" do
+      render_inline(described_class.new(variant: :outline)) { "Action" }
+      expect(page).not_to have_css(".usa-button--inverse")
+    end
+
+    it "adds usa-button--inverse when inverse: true" do
+      render_inline(described_class.new(variant: :outline, inverse: true)) { "Action" }
+      expect(page).to have_css("button.usa-button.usa-button--outline.usa-button--inverse", text: "Action")
+    end
+  end
+
+  describe "type" do
+    it "renders type='button' by default" do
+      render_inline(described_class.new) { "X" }
+      expect(page).to have_css("button[type='button']")
+    end
+
+    it "renders type='submit' when type: :submit" do
+      render_inline(described_class.new(type: :submit)) { "Save" }
+      expect(page).to have_css("button[type='submit']", text: "Save")
+    end
+
+    it "renders type='reset' when type: :reset" do
+      render_inline(described_class.new(type: :reset)) { "Reset" }
+      expect(page).to have_css("button[type='reset']", text: "Reset")
+    end
+  end
+
+  describe "href (link-styled button)" do
+    it "renders an <a> instead of a <button> when href is set" do
+      render_inline(described_class.new(href: "/edit")) { "Edit" }
+
+      expect(page).to have_css("a.usa-button[href='/edit']", text: "Edit")
+      expect(page).not_to have_css("button")
+    end
+
+    it "does not set a type attribute on the anchor" do
+      render_inline(described_class.new(href: "/edit", type: :submit)) { "Edit" }
+      expect(page).not_to have_css("a[type]")
+    end
+
+    it "propagates variants and sizes onto the anchor" do
+      render_inline(described_class.new(href: "/edit", variant: :outline, size: :big)) { "Edit" }
+      expect(page).to have_css("a.usa-button.usa-button--outline.usa-button--big[href='/edit']", text: "Edit")
+    end
+  end
+
+  describe "disabled" do
+    it "adds the disabled attribute to a <button>" do
+      render_inline(described_class.new(disabled: true)) { "Save" }
+      expect(page).to have_css("button[disabled]", text: "Save")
+      expect(page).not_to have_css("button[aria-disabled]")
+    end
+
+    it "adds aria-disabled='true' to an <a> but does not remove the href" do
+      render_inline(described_class.new(href: "/edit", disabled: true)) { "Edit" }
+      expect(page).to have_css("a.usa-button[href='/edit'][aria-disabled='true']", text: "Edit")
+      expect(page).not_to have_css("a[disabled]")
+    end
+  end
+
+  describe "extra classes & html attributes" do
+    it "appends classes after the USWDS classes" do
+      render_inline(described_class.new(classes: "margin-top-2 extra")) { "Action" }
+
+      expect(page).to have_css("button.usa-button.margin-top-2.extra", text: "Action")
+    end
+
+    it "forwards id, data-*, and aria-* attributes to the button" do
+      render_inline(described_class.new(
+        id: "my-btn",
+        data: { test: "yes" },
+        "aria-label": "click me"
+      )) { "Action" }
+
+      expect(page).to have_css("button#my-btn[data-test='yes'][aria-label='click me']")
+    end
+
+    it "forwards html attributes to the anchor when href is set" do
+      render_inline(described_class.new(href: "/edit", id: "edit-link", data: { turbo: "false" })) { "Edit" }
+
+      expect(page).to have_css("a#edit-link[href='/edit'][data-turbo='false']", text: "Edit")
+    end
+
+    it "prefers the dedicated classes: keyword when html_attributes also carries :class" do
+      render_inline(described_class.new(classes: "from-classes", class: "from-html-attrs")) { "Action" }
+
+      expect(page).to have_css("button.usa-button.from-classes")
+      expect(page).not_to have_css("button.from-html-attrs")
+    end
+  end
+
+  describe "content block" do
+    it "escapes plain text content" do
+      render_inline(described_class.new) { "<script>alert(1)</script>" }
+
+      html = page.native.to_html
+      expect(html).not_to include("<script>alert(1)</script>")
+      expect(html).to include("&lt;script&gt;")
+    end
+
+    it "renders html_safe content as HTML" do
+      render_inline(described_class.new) { "<strong>Save</strong>".html_safe }
+
+      expect(page).to have_css("button strong", text: "Save")
+    end
+  end
+
+  describe ".css_classes" do
+    it "returns just 'usa-button' for defaults" do
+      expect(described_class.css_classes).to eq("usa-button")
+    end
+
+    it "includes the variant modifier" do
+      expect(described_class.css_classes(variant: :secondary)).to eq("usa-button usa-button--secondary")
+    end
+
+    it "includes the size modifier" do
+      expect(described_class.css_classes(size: :big)).to eq("usa-button usa-button--big")
+    end
+
+    it "includes usa-button--inverse when inverse: true" do
+      expect(described_class.css_classes(variant: :outline, inverse: true))
+        .to eq("usa-button usa-button--outline usa-button--inverse")
+    end
+
+    it "combines variant, size, and inverse in a stable order" do
+      expect(described_class.css_classes(variant: :outline, size: :big, inverse: true))
+        .to eq("usa-button usa-button--outline usa-button--big usa-button--inverse")
+    end
+
+    it "raises ArgumentError on an unknown variant" do
+      expect { described_class.css_classes(variant: :nonsense) }
+        .to raise_error(ArgumentError, /variant/)
+    end
+
+    it "raises ArgumentError on an unknown size" do
+      expect { described_class.css_classes(size: :huge) }
+        .to raise_error(ArgumentError, /size/)
+    end
+  end
+end

--- a/spec/components/strata/us/button_group_component_spec.rb
+++ b/spec/components/strata/us/button_group_component_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Strata::US::ButtonGroupComponent, type: :component do
+  describe "structural markup" do
+    it "renders a ul.usa-button-group" do
+      render_inline(described_class.new) do |group|
+        group.with_item { "A" }
+      end
+
+      expect(page).to have_css("ul.usa-button-group")
+    end
+
+    it "wraps each item in li.usa-button-group__item" do
+      render_inline(described_class.new) do |group|
+        group.with_item { "A" }
+        group.with_item { "B" }
+      end
+
+      expect(page).to have_css("ul.usa-button-group > li.usa-button-group__item", count: 2)
+      expect(page).to have_css("li.usa-button-group__item", text: "A")
+      expect(page).to have_css("li.usa-button-group__item", text: "B")
+    end
+
+    it "renders an empty <ul> when no items are added" do
+      render_inline(described_class.new)
+
+      expect(page).to have_css("ul.usa-button-group")
+      expect(page).not_to have_css("li")
+    end
+  end
+
+  describe "segmented variant" do
+    it "omits usa-button-group--segmented by default" do
+      render_inline(described_class.new) { |group| group.with_item { "A" } }
+
+      expect(page).not_to have_css(".usa-button-group--segmented")
+    end
+
+    it "adds usa-button-group--segmented when segmented: true" do
+      render_inline(described_class.new(segmented: true)) { |group| group.with_item { "A" } }
+
+      expect(page).to have_css("ul.usa-button-group.usa-button-group--segmented")
+    end
+  end
+
+  describe "extra classes & html attributes" do
+    it "appends extra classes after the USWDS classes" do
+      render_inline(described_class.new(classes: "margin-top-4 extra")) do |group|
+        group.with_item { "A" }
+      end
+
+      expect(page).to have_css("ul.usa-button-group.margin-top-4.extra")
+    end
+
+    it "forwards id, data-*, and role attributes to the <ul>" do
+      render_inline(described_class.new(id: "my-group", data: { test: "yes" }, role: "group")) do |group|
+        group.with_item { "A" }
+      end
+
+      expect(page).to have_css("ul#my-group[data-test='yes'][role='group']")
+    end
+
+    it "prefers the dedicated classes: keyword when html_attributes also carries :class" do
+      render_inline(described_class.new(classes: "from-classes", class: "from-html-attrs")) do |group|
+        group.with_item { "A" }
+      end
+
+      expect(page).to have_css("ul.usa-button-group.from-classes")
+      expect(page).not_to have_css("ul.from-html-attrs")
+    end
+  end
+
+  describe "item-level options" do
+    it "applies item-level classes to the <li>" do
+      render_inline(described_class.new) do |group|
+        group.with_item(classes: "highlighted") { "A" }
+      end
+
+      expect(page).to have_css("li.usa-button-group__item.highlighted", text: "A")
+    end
+
+    it "forwards item-level html attributes to the <li>" do
+      render_inline(described_class.new) do |group|
+        group.with_item(id: "first-item", data: { index: "0" }) { "A" }
+      end
+
+      expect(page).to have_css("li#first-item[data-index='0']", text: "A")
+    end
+  end
+
+  describe "content inside items" do
+    it "renders arbitrary HTML inside items" do
+      render_inline(described_class.new) do |group|
+        group.with_item { "<a class='usa-button' href='/x'>Go</a>".html_safe }
+      end
+
+      expect(page).to have_css("li.usa-button-group__item a.usa-button[href='/x']", text: "Go")
+    end
+
+    it "escapes plain string content" do
+      render_inline(described_class.new) do |group|
+        group.with_item { "<script>alert(1)</script>" }
+      end
+
+      html = page.native.to_html
+      expect(html).not_to include("<script>alert(1)</script>")
+      expect(html).to include("&lt;script&gt;")
+    end
+  end
+end

--- a/spec/helpers/strata/form_builder_spec.rb
+++ b/spec/helpers/strata/form_builder_spec.rb
@@ -341,11 +341,52 @@ RSpec.describe Strata::FormBuilder do
       expect(result).to have_element(:input, type: 'submit', class: 'usa-button')
     end
 
+    it 'does not add variant modifier classes by default' do
+      expect(result).not_to have_css('input.usa-button--secondary')
+      expect(result).not_to have_css('input.usa-button--outline')
+      expect(result).not_to have_css('input.usa-button--big')
+    end
+
     context 'with big set to true' do
       let (:result) { builder.submit(nil, { big: true }) }
 
       it 'outputs a big submit button' do
         expect(result).to have_element(:input, type: 'submit', class: 'usa-button--big')
+      end
+
+      it 'preserves the margin-y-6 spacing for big submits' do
+        expect(result).to have_element(:input, class: /margin-y-6/)
+      end
+    end
+
+    context 'with a variant' do
+      let (:result) { builder.submit(nil, { variant: :outline }) }
+
+      it 'applies the variant modifier alongside usa-button' do
+        expect(result).to have_element(:input, type: 'submit', class: 'usa-button usa-button--outline')
+      end
+
+      it 'does not leak the :variant key onto the input as an attribute' do
+        expect(result).not_to have_css('input[variant]')
+      end
+    end
+
+    context 'with both :variant and :big' do
+      let (:result) { builder.submit(nil, { variant: :secondary, big: true }) }
+
+      it 'combines variant + size + spacing modifiers' do
+        expect(result).to have_element(
+          :input,
+          type: 'submit',
+          class: 'usa-button usa-button--secondary usa-button--big margin-y-6'
+        )
+      end
+    end
+
+    context 'with an unknown variant' do
+      it 'raises ArgumentError' do
+        expect { builder.submit(nil, { variant: :nonsense }) }
+          .to raise_error(ArgumentError, /variant/)
       end
     end
   end


### PR DESCRIPTION
## Changes

- Adds **`Strata::US::ButtonComponent`** — a USWDS-styled button rendered as either a `<button>` or an `<a>` (via `href:`). Supports `variant:`, `size:`, `inverse:`, `disabled:`, `type:`, plus the standard `classes:` / extra HTML attribute forwarding.
- Adds **`Strata::US::ButtonGroupComponent`** — `<ul class="usa-button-group">` with each entry wrapped in `<li class="usa-button-group__item">`. Supports the segmented variant.
- Lookbook previews for both components.
- RSpec coverage: 31 examples for `ButtonComponent`, 12 for `ButtonGroupComponent`.
- Refactors `FormBuilder#submit` to delegate to `ButtonComponent.css_classes` and gain a `:variant` option for non-primary submits. The existing `:big` option and `margin-y-6` spacing are preserved.
- Updates `docs/uswds-components.md` with **Button** and **Button Group** sections.

## Context

Two new ViewComponents in the `Strata::US` namespace, following the existing one-module-per-component pattern (Alert, Breadcrumbs, Card, etc.).

`ButtonComponent` exposes a class method, **`.css_classes(variant:, size:, inverse:)`**, that returns just the bare USWDS class string. This is intentionally the single source of truth used by:
- the component itself,
- `FormBuilder#submit` (this PR),
- the `strata_link_to` / `strata_button_to` view helpers (follow-up PR),
- any caller that needs to apply USWDS button styling to a Rails-rendered tag (`button_to`, `link_to`, `form.button`).

`ButtonGroupComponent` mirrors the structure of `BreadcrumbsComponent` — the parent renders a `<ul>`, each `with_item` slot produces a nested `ItemComponent` that renders as `<li>`.

The `FormBuilder#submit` refactor lives in this PR rather than the adoption PR because the component should land with at least one consumer — leaving `submit` on hand-written class strings would mean shipping an unused abstraction.

**This PR is the base of a three-PR stack:**
1. **This PR** — components + `FormBuilder#submit` refactor
2. `cael/uswds-button-helpers` — adds `strata_link_to` / `strata_button_to` view helpers
3. `cael/uswds-button-adoption` — migrates every hand-written `usa-button` / `usa-button-group` call site to the new component + helpers

## Testing

```
$ make lint-ci
351 files inspected, no offenses detected

$ make test
1379 examples, 0 failures
```

Test plan:

- [ ] `bundle exec rspec spec/components/strata/us/button_component_spec.rb` — 31 examples cover defaults, every variant, sizes, inverse, type, href switch, disabled (button vs anchor), extra classes/HTML attributes, content escaping, and the `.css_classes` class method.
- [ ] `bundle exec rspec spec/components/strata/us/button_group_component_spec.rb` — 12 examples cover structural markup, the segmented variant, item-level classes/attributes, and content rendering/escaping.
- [ ] `bundle exec rspec spec/helpers/strata/form_builder_spec.rb -e submit` — regression specs covering default styling, `:big`, `:variant`, `:big + :variant`, and `ArgumentError` on unknown variants.
- [ ] Browse Lookbook (`make start` → http://localhost:3000/lookbook) and visually verify the Button and Button Group previews.