### PR TITLE
Add USWDS LinkComponent + strata_link_to :external treatment

### DIFF
--- a/app/components/strata/us/link_component.html.erb
+++ b/app/components/strata/us/link_component.html.erb
@@ -1,0 +1,1 @@
+<%= content_tag :a, **element_attributes do %><%= content %><% end %>

--- a/app/components/strata/us/link_component.rb
+++ b/app/components/strata/us/link_component.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Strata
+  module US
+    # LinkComponent renders a USWDS-styled <a>. The component applies styling
+    # only — it does not set +target+ or +rel+. Callers that want to open a
+    # link in a new tab should pass +target: "_blank"+ and
+    # +rel: "noopener noreferrer"+ explicitly.
+    #
+    # See https://designsystem.digital.gov/components/link/.
+    #
+    # The +strata_link_to+ view helper (see Strata::LinksHelper) wraps Rails'
+    # +link_to+ and applies this styling for Rails-rendered tags via the
+    # +as: :external+ treatment. For other call sites, pass
+    # +Strata::US::LinkComponent.css_classes+ as the +:class+. The class-method
+    # helper is the single source of truth.
+    #
+    # @example A plain styled link
+    #   <%= render Strata::US::LinkComponent.new(href: article_path) do %>
+    #     Read more
+    #   <% end %>
+    #
+    # @example An external link (caller-controlled target/rel)
+    #   <%= render Strata::US::LinkComponent.new(
+    #         href: "https://example.gov",
+    #         external: true,
+    #         target: "_blank",
+    #         rel: "noopener noreferrer") do %>
+    #     example.gov
+    #   <% end %>
+    #
+    # @example The view helper
+    #   <%= strata_link_to "Read more", "https://example.gov", as: :external %>
+    class LinkComponent < ViewComponent::Base
+      def initialize(
+        href:,
+        external: false,
+        alt: false,
+        classes: nil,
+        **html_attributes
+      )
+        @href = href
+        @external = external
+        @alt = alt
+        @classes = classes
+        @html_attributes = html_attributes
+      end
+
+      # Returns the USWDS class string for a link-styled element, without
+      # rendering the element itself. Use this for +link_to+ and other call
+      # sites where Rails owns the tag.
+      #
+      # +alt: true+ without +external: true+ is a no-op — +usa-link--alt+ is
+      # only meaningful in combination with +usa-link--external+.
+      def self.css_classes(external: false, alt: false)
+        parts = [ "usa-link" ]
+        parts << "usa-link--external" if external
+        parts << "usa-link--alt" if external && alt
+        parts.join(" ")
+      end
+
+      def element_attributes
+        attrs = @html_attributes.dup
+        attrs[:class] = combined_classes
+        attrs[:href] = @href
+        attrs
+      end
+
+      private
+
+      def combined_classes
+        base = self.class.css_classes(external: @external, alt: @alt)
+        @classes.present? ? "#{base} #{@classes}" : base
+      end
+    end
+  end
+end

--- a/app/helpers/strata/links_helper.rb
+++ b/app/helpers/strata/links_helper.rb
@@ -3,7 +3,8 @@
 module Strata
   # LinksHelper provides Strata's view-helper wrappers around Rails' +link_to+.
   # The helper defaults to a passthrough; pass +:as+ to opt into a styling
-  # treatment (currently +:button+, with room to grow — e.g. +:external+).
+  # treatment (+:button+ for USWDS button styling, +:external+ for the USWDS
+  # external-link styling).
   #
   # @example A plain link (passthrough)
   #   <%= strata_link_to "Read more", article_path %>
@@ -11,22 +12,34 @@ module Strata
   # @example A button-styled link
   #   <%= strata_link_to "Back", root_path, as: :button, variant: :outline %>
   #
+  # @example A USWDS external link
+  #   <%= strata_link_to "Read the docs", "https://example.gov", as: :external %>
+  #
   # @see Strata::US::ButtonComponent
+  # @see Strata::US::LinkComponent
   module LinksHelper
     # Allowed values for the +:as+ keyword on +strata_link_to+.
-    STRATA_LINK_TREATMENTS = %i[button].freeze
+    STRATA_LINK_TREATMENTS = %i[button external].freeze
 
     # Renders a Rails +link_to+ with an optional Strata styling treatment
     # controlled by the +:as+ keyword. Without +:as+, it's a pure passthrough.
+    #
     # With +as: :button+, applies USWDS button styling via
     # Strata::US::ButtonComponent.css_classes and accepts +:variant+, +:size+,
-    # and +:inverse+ to control the styling. A caller-supplied +:class+ is
-    # appended to the treatment's classes.
+    # and +:inverse+.
+    #
+    # With +as: :external+, applies USWDS external-link styling via
+    # Strata::US::LinkComponent.css_classes and accepts +:alt+ for the
+    # dark-background variant. Styling only — pass +target:+ / +rel:+
+    # explicitly if you want the link to open in a new tab.
+    #
+    # A caller-supplied +:class+ is appended to the treatment's classes.
     #
     # Raises ArgumentError if +:as+ is unrecognized, or if +:variant+/+:size+/
     # +:inverse+ are passed without +as: :button+.
     def strata_link_to(*args, as: nil, **html_options, &block)
       button_kwargs = html_options.extract!(:variant, :size, :inverse)
+      link_kwargs = html_options.extract!(:alt)
 
       case as
       when nil
@@ -39,6 +52,10 @@ module Strata
       when :button
         button_classes = Strata::US::ButtonComponent.css_classes(**button_kwargs)
         html_options[:class] = class_names(button_classes, html_options[:class])
+        link_to(*args, **html_options, &block)
+      when :external
+        link_classes = Strata::US::LinkComponent.css_classes(external: true, **link_kwargs)
+        html_options[:class] = class_names(link_classes, html_options[:class])
         link_to(*args, **html_options, &block)
       else
         raise ArgumentError,

--- a/app/previews/strata/us/link_component_preview.rb
+++ b/app/previews/strata/us/link_component_preview.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Strata
+  module US
+    # LinkComponentPreview provides preview examples for the Strata::US::LinkComponent.
+    class LinkComponentPreview < Lookbook::Preview
+      layout "strata/component_preview"
+
+      # @label Default
+      def default
+        render Strata::US::LinkComponent.new(href: "#") do
+          "Default link"
+        end
+      end
+
+      # @label External
+      def external
+        render Strata::US::LinkComponent.new(href: "https://designsystem.digital.gov/", external: true) do
+          "USWDS"
+        end
+      end
+
+      # @label External (alt) on a dark background
+      def external_alt
+        content_tag(
+          :div,
+          render(Strata::US::LinkComponent.new(href: "https://designsystem.digital.gov/", external: true, alt: true) do
+            "USWDS"
+          end),
+          style: "background-color: #1b1b1b; color: white; padding: 1rem;"
+        )
+      end
+
+      # @label Opens in a new tab (caller-controlled target/rel)
+      def new_tab
+        render Strata::US::LinkComponent.new(
+          href: "https://designsystem.digital.gov/",
+          external: true,
+          target: "_blank",
+          rel: "noopener noreferrer"
+        ) do
+          "USWDS"
+        end
+      end
+    end
+  end
+end

--- a/app/previews/strata/us/link_component_preview.rb
+++ b/app/previews/strata/us/link_component_preview.rb
@@ -21,15 +21,7 @@ module Strata
       end
 
       # @label External (alt) on a dark background
-      def external_alt
-        content_tag(
-          :div,
-          render(Strata::US::LinkComponent.new(href: "https://designsystem.digital.gov/", external: true, alt: true) do
-            "USWDS"
-          end),
-          style: "background-color: #1b1b1b; color: white; padding: 1rem;"
-        )
-      end
+      def external_alt; end
 
       # @label Opens in a new tab (caller-controlled target/rel)
       def new_tab

--- a/app/previews/strata/us/link_component_preview/external_alt.html.erb
+++ b/app/previews/strata/us/link_component_preview/external_alt.html.erb
@@ -1,0 +1,5 @@
+<div style="background-color: #1b1b1b; color: white; padding: 1rem;">
+  <%= render Strata::US::LinkComponent.new(href: "https://designsystem.digital.gov/", external: true, alt: true) do %>
+    USWDS
+  <% end %>
+</div>

--- a/docs/strata-view-helpers.md
+++ b/docs/strata-view-helpers.md
@@ -7,7 +7,7 @@ Strata ships a small set of Rails view helpers that wrap common Rails primitives
 1. [`strata_link_to`](#strata_link_to) — Rails `link_to` with opt-in styling treatments
 2. [`strata_button_to`](#strata_button_to) — Rails `button_to` with USWDS button styling
 
-For the underlying ViewComponent, see [Strata::US::ButtonComponent in uswds-components.md](./uswds-components.md#button).
+For the underlying ViewComponents, see [Strata::US::ButtonComponent](./uswds-components.md#button) and [Strata::US::LinkComponent](./uswds-components.md#link) in [uswds-components.md](./uswds-components.md).
 
 ---
 
@@ -15,7 +15,7 @@ For the underlying ViewComponent, see [Strata::US::ButtonComponent in uswds-comp
 
 Defined in [Strata::LinksHelper](../app/helpers/strata/links_helper.rb).
 
-A wrapper around Rails' `link_to`. Without an `:as` keyword it's a pure passthrough — the helper exists as a single entry point for any Strata link styling. Pass `as: :button` to opt into USWDS button styling.
+A wrapper around Rails' `link_to`. Without an `:as` keyword it's a pure passthrough — the helper exists as a single entry point for any Strata link styling. Pass `as: :button` to opt into USWDS button styling, or `as: :external` for the USWDS external-link treatment.
 
 **Signature**
 
@@ -26,13 +26,14 @@ strata_link_to(*args, as: nil, **html_options, &block)
 `*args`, `**html_options`, and `&block` match Rails' `link_to`. The recognized treatments:
 
 - `as: :button` — applies USWDS button styling. Accepts the additional keywords `:variant`, `:size`, and `:inverse` (same values as [`Strata::US::ButtonComponent`](./uswds-components.md#button)).
+- `as: :external` — applies USWDS external-link styling (`usa-link usa-link--external`). Accepts `:alt` for the dark-background variant (`usa-link--alt`). The helper does not set `target` or `rel`; pass them explicitly if you want the link to open in a new tab.
 
 A caller-supplied `:class` is appended to the treatment's classes.
 
 **Errors**
 
 - Raises `ArgumentError` if `:variant`, `:size`, or `:inverse` are passed without `as: :button` — catches the "forgot to opt in" mistake that would otherwise silently produce a plain link.
-- Raises `ArgumentError` on an unrecognized `:as` value (currently only `:button` is supported).
+- Raises `ArgumentError` on an unrecognized `:as` value (currently `:button` and `:external` are supported).
 
 **Examples**
 
@@ -45,6 +46,13 @@ A caller-supplied `:class` is appended to the treatment's classes.
 
 <%# Button-styled link with extra layout classes %>
 <%= strata_link_to "Continue", next_path, as: :button, variant: :secondary, class: "margin-top-4" %>
+
+<%# External link %>
+<%= strata_link_to "USWDS docs", "https://designsystem.digital.gov/", as: :external %>
+
+<%# External link that opens in a new tab — caller controls target/rel %>
+<%= strata_link_to "USWDS docs", "https://designsystem.digital.gov/",
+      as: :external, target: "_blank", rel: "noopener noreferrer" %>
 
 <%# Block form %>
 <%= strata_link_to article_path, as: :button do %>

--- a/docs/uswds-components.md
+++ b/docs/uswds-components.md
@@ -21,8 +21,9 @@ Every component accepts a `classes:` keyword for additional CSS classes and forw
 5. [Button Group](#button-group)
 6. [Card](#card)
 7. [Card Group](#card-group)
-8. [List](#list)
-9. [Table](#table)
+8. [Link](#link)
+9. [List](#list)
+10. [Table](#table)
 
 ---
 
@@ -276,6 +277,50 @@ At least one of header, media, body, or footer must be provided.
   <% end %>
 <% end %>
 ```
+
+---
+
+## Link
+
+`Strata::US::LinkComponent` — a USWDS-styled `<a>`, with an opt-in external-link indicator. See [USWDS Link](https://designsystem.digital.gov/components/link/) and the [Lookbook preview](../app/previews/strata/us/link_component_preview.rb).
+
+The component applies styling only — it does not set `target` or `rel`. If you want the link to open in a new tab, pass `target: "_blank"` and `rel: "noopener noreferrer"` explicitly.
+
+**Options**
+
+- `href:` (required) — the link target.
+- `external:` — render the external-link indicator (`usa-link--external`). Defaults to `false`.
+- `alt:` — render the dark-background variant of the external indicator (`usa-link--alt`). Only meaningful in combination with `external: true`; otherwise ignored. Defaults to `false`.
+- `classes:` — extra CSS classes appended to the `<a>`.
+
+Any other keyword arguments are forwarded as HTML attributes on the `<a>`.
+
+**Example**
+
+```erb
+<%= render Strata::US::LinkComponent.new(href: article_path) do %>
+  Read more
+<% end %>
+
+<%= render Strata::US::LinkComponent.new(href: "https://example.gov", external: true) do %>
+  example.gov
+<% end %>
+
+<%# External link that opens in a new tab — caller controls target/rel %>
+<%= render Strata::US::LinkComponent.new(
+      href: "https://example.gov",
+      external: true,
+      target: "_blank",
+      rel: "noopener noreferrer") do %>
+  example.gov
+<% end %>
+```
+
+### Helpers and `css_classes`
+
+For `link_to` call sites, use `strata_link_to ..., as: :external` instead of rendering this component. See [strata-view-helpers.md](./strata-view-helpers.md).
+
+For other call sites where Rails owns the tag, use the class-method helper `Strata::US::LinkComponent.css_classes(external:, alt:)` directly. It returns the bare USWDS class string and is the single source of truth used by the component and the helper.
 
 ---
 

--- a/spec/components/strata/us/link_component_spec.rb
+++ b/spec/components/strata/us/link_component_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Strata::US::LinkComponent, type: :component do
+  describe "default render" do
+    it "renders an <a> with the base usa-link class" do
+      render_inline(described_class.new(href: "/articles/1")) { "Read more" }
+
+      expect(page).to have_css("a.usa-link[href='/articles/1']", text: "Read more")
+    end
+
+    it "does not add any modifier classes by default" do
+      render_inline(described_class.new(href: "/articles/1")) { "Read more" }
+
+      expect(page).not_to have_css(".usa-link--external")
+      expect(page).not_to have_css(".usa-link--alt")
+    end
+
+    it "does not set target or rel by default" do
+      render_inline(described_class.new(href: "/articles/1")) { "Read more" }
+
+      expect(page).not_to have_css("a[target]")
+      expect(page).not_to have_css("a[rel]")
+    end
+  end
+
+  describe "external" do
+    it "adds usa-link--external when external: true" do
+      render_inline(described_class.new(href: "https://example.com", external: true)) { "Example" }
+
+      expect(page).to have_css("a.usa-link.usa-link--external[href='https://example.com']", text: "Example")
+    end
+
+    it "does not add usa-link--alt when external: true without alt: true" do
+      render_inline(described_class.new(href: "https://example.com", external: true)) { "Example" }
+
+      expect(page).not_to have_css(".usa-link--alt")
+    end
+
+    it "does not auto-set target or rel when external: true" do
+      render_inline(described_class.new(href: "https://example.com", external: true)) { "Example" }
+
+      expect(page).not_to have_css("a[target]")
+      expect(page).not_to have_css("a[rel]")
+    end
+  end
+
+  describe "alt" do
+    it "adds usa-link--alt when external: true and alt: true" do
+      render_inline(described_class.new(href: "https://example.com", external: true, alt: true)) { "Example" }
+
+      expect(page).to have_css("a.usa-link.usa-link--external.usa-link--alt[href='https://example.com']", text: "Example")
+    end
+
+    it "is a no-op when alt: true is passed without external: true" do
+      render_inline(described_class.new(href: "/articles/1", alt: true)) { "Read more" }
+
+      expect(page).to have_css("a.usa-link[href='/articles/1']", text: "Read more")
+      expect(page).not_to have_css(".usa-link--alt")
+      expect(page).not_to have_css(".usa-link--external")
+    end
+  end
+
+  describe "extra classes & html attributes" do
+    it "appends classes after the USWDS classes" do
+      render_inline(described_class.new(href: "/x", classes: "margin-top-2 extra")) { "Link" }
+
+      expect(page).to have_css("a.usa-link.margin-top-2.extra", text: "Link")
+    end
+
+    it "forwards id, data-*, and aria-* attributes to the anchor" do
+      render_inline(described_class.new(
+        href: "/x",
+        id: "my-link",
+        data: { test: "yes" },
+        "aria-label": "click me"
+      )) { "Link" }
+
+      expect(page).to have_css("a#my-link[data-test='yes'][aria-label='click me']")
+    end
+
+    it "forwards target and rel when explicitly set by the caller" do
+      render_inline(described_class.new(
+        href: "https://example.com",
+        external: true,
+        target: "_blank",
+        rel: "noopener noreferrer"
+      )) { "Example" }
+
+      expect(page).to have_css("a.usa-link.usa-link--external[target='_blank'][rel='noopener noreferrer']")
+    end
+
+    it "prefers the dedicated classes: keyword when html_attributes also carries :class" do
+      render_inline(described_class.new(href: "/x", classes: "from-classes", class: "from-html-attrs")) { "Link" }
+
+      expect(page).to have_css("a.usa-link.from-classes")
+      expect(page).not_to have_css("a.from-html-attrs")
+    end
+  end
+
+  describe "content block" do
+    it "escapes plain text content" do
+      render_inline(described_class.new(href: "/x")) { "<script>alert(1)</script>" }
+
+      html = page.native.to_html
+      expect(html).not_to include("<script>alert(1)</script>")
+      expect(html).to include("&lt;script&gt;")
+    end
+
+    it "renders html_safe content as HTML" do
+      render_inline(described_class.new(href: "/x")) { "<strong>Read more</strong>".html_safe }
+
+      expect(page).to have_css("a strong", text: "Read more")
+    end
+  end
+
+  describe ".css_classes" do
+    it "returns just 'usa-link' for defaults" do
+      expect(described_class.css_classes).to eq("usa-link")
+    end
+
+    it "includes usa-link--external when external: true" do
+      expect(described_class.css_classes(external: true)).to eq("usa-link usa-link--external")
+    end
+
+    it "combines external and alt in a stable order" do
+      expect(described_class.css_classes(external: true, alt: true))
+        .to eq("usa-link usa-link--external usa-link--alt")
+    end
+
+    it "ignores alt: true when external: false (no-op)" do
+      expect(described_class.css_classes(alt: true)).to eq("usa-link")
+    end
+  end
+end

--- a/spec/helpers/strata/links_helper_spec.rb
+++ b/spec/helpers/strata/links_helper_spec.rb
@@ -115,6 +115,101 @@ RSpec.describe Strata::LinksHelper, type: :helper do
       end
     end
 
+    context "with `as: :external`" do
+      it "renders an <a> with the usa-link and usa-link--external classes" do
+        result = helper.strata_link_to("Example", "https://example.gov", as: :external)
+
+        expect(result).to have_element(
+          :a,
+          href: "https://example.gov",
+          class: "usa-link usa-link--external",
+          text: "Example"
+        )
+      end
+
+      it "adds usa-link--alt when alt: true" do
+        result = helper.strata_link_to("Example", "https://example.gov", as: :external, alt: true)
+
+        expect(result).to have_element(
+          :a,
+          class: "usa-link usa-link--external usa-link--alt"
+        )
+      end
+
+      it "does not auto-set target or rel" do
+        result = helper.strata_link_to("Example", "https://example.gov", as: :external)
+
+        expect(result).not_to have_css("a[target]")
+        expect(result).not_to have_css("a[rel]")
+      end
+
+      it "forwards an explicit target and rel from the caller" do
+        result = helper.strata_link_to(
+          "Example",
+          "https://example.gov",
+          as: :external,
+          target: "_blank",
+          rel: "noopener noreferrer"
+        )
+
+        expect(result).to have_element(
+          :a,
+          target: "_blank",
+          rel: "noopener noreferrer"
+        )
+      end
+
+      it "merges a user-provided :class with the link classes" do
+        result = helper.strata_link_to(
+          "Example",
+          "https://example.gov",
+          as: :external,
+          class: "margin-top-4"
+        )
+
+        expect(result).to have_element(:a, class: "usa-link usa-link--external margin-top-4")
+      end
+
+      it "forwards arbitrary html_options to link_to (id, data-*, aria-*)" do
+        result = helper.strata_link_to(
+          "Example",
+          "https://example.gov",
+          as: :external,
+          id: "example-link",
+          data: { turbo: "false" },
+          "aria-label": "Visit example.gov"
+        )
+
+        expect(result).to have_element(
+          :a,
+          id: "example-link",
+          "data-turbo": "false",
+          "aria-label": "Visit example.gov"
+        )
+      end
+
+      it "supports the block form" do
+        result = helper.strata_link_to("https://example.gov", as: :external) { "Example" }
+
+        expect(result).to have_element(
+          :a,
+          href: "https://example.gov",
+          class: "usa-link usa-link--external",
+          text: "Example"
+        )
+      end
+    end
+
+    context "when :alt is passed without `as: :external`" do
+      it "silently drops :alt when no :as is given (no error, no stray attribute on the <a>)" do
+        result = helper.strata_link_to("Read more", "/articles/1", alt: true)
+
+        expect(result).to have_element(:a, href: "/articles/1", text: "Read more")
+        expect(result).not_to have_css("a[alt]")
+        expect(result).not_to have_css(".usa-link--alt")
+      end
+    end
+
     context "with an unknown :as value" do
       it "raises ArgumentError" do
         expect { helper.strata_link_to("X", "/x", as: :nonsense) }


### PR DESCRIPTION
## Summary

- Adds `Strata::US::LinkComponent` for USWDS-styled links, with opt-in external-link styling (`usa-link--external`, `usa-link--alt`). Pure styling — callers control `target`/`rel`.
- Adds an `as: :external` treatment to `strata_link_to` that delegates to `LinkComponent.css_classes` (single source of truth).
- New Lookbook preview, component spec, helper spec coverage, and doc updates in `uswds-components.md` and `strata-view-helpers.md`.

Closes #364

## Test plan

- [x] `make lint` clean
- [x] `make test` — 1429 examples, 0 failures
- [ ] `make start` + visit `/lookbook` to eyeball the preview variants

🤖 Generated with [Claude Code](https://claude.ai/code)