### PR TITLE
Add Strata::US::IconComponent for USWDS icons

### DIFF
--- a/app/components/strata/us/icon_component.html.erb
+++ b/app/components/strata/us/icon_component.html.erb
@@ -1,0 +1,4 @@
+<svg <%= tag.attributes(svg_attributes) %>>
+  <% if show_title? %><title id="<%= title_id %>"><%= title_text %></title><% end %>
+  <use href="<%= sprite_href %>"></use>
+</svg>

--- a/app/components/strata/us/icon_component.rb
+++ b/app/components/strata/us/icon_component.rb
@@ -46,16 +46,15 @@ module Strata
       end
 
       def svg_attributes
-        attrs = @html_attributes.dup
+        # focusable and role default to USWDS values but may be overridden by
+        # the caller. aria-hidden is component-managed via `decorative:` and
+        # cannot be overridden.
+        attrs = { focusable: "false", role: "img" }.merge(@html_attributes)
         attrs[:class] = svg_classes
-        attrs[:focusable] = "false"
-        attrs[:role] = "img"
 
         if @decorative
           attrs[:"aria-hidden"] = "true"
         else
-          # Strip any caller-supplied aria-hidden so a meaningful icon can't be
-          # silently hidden from AT.
           attrs.delete(:"aria-hidden")
           attrs[:"aria-labelledby"] = title_id
         end

--- a/app/components/strata/us/icon_component.rb
+++ b/app/components/strata/us/icon_component.rb
@@ -29,13 +29,13 @@ module Strata
       ALLOWED_SIZES = (3..9).freeze
 
       def initialize(name:, size: nil, decorative: true, title: nil, classes: nil, **html_attributes)
-        raise ArgumentError, "name is required" if name.nil? || name.to_s.empty?
+        raise ArgumentError, "name is required" if name.blank?
         validate_size!(size) unless size.nil?
 
         @decorative = decorative
         @title = title
 
-        if !@decorative && (@title.nil? || @title.to_s.empty?)
+        if !@decorative && @title.blank?
           raise ArgumentError, "title is required when decorative: false"
         end
 
@@ -54,6 +54,9 @@ module Strata
         if @decorative
           attrs[:"aria-hidden"] = "true"
         else
+          # Strip any caller-supplied aria-hidden so a meaningful icon can't be
+          # silently hidden from AT.
+          attrs.delete(:"aria-hidden")
           attrs[:"aria-labelledby"] = title_id
         end
 

--- a/app/components/strata/us/icon_component.rb
+++ b/app/components/strata/us/icon_component.rb
@@ -47,15 +47,20 @@ module Strata
 
       def svg_attributes
         # focusable and role default to USWDS values but may be overridden by
-        # the caller. aria-hidden is component-managed via `decorative:` and
-        # cannot be overridden.
+        # the caller. aria-hidden is component-managed via `decorative:` —
+        # strip both the flat and nested forms before applying it.
         attrs = { focusable: "false", role: "img" }.merge(@html_attributes)
         attrs[:class] = svg_classes
+
+        attrs.delete(:"aria-hidden")
+        if attrs[:aria].is_a?(Hash)
+          attrs[:aria] = attrs[:aria].except(:hidden, "hidden")
+          attrs.delete(:aria) if attrs[:aria].empty?
+        end
 
         if @decorative
           attrs[:"aria-hidden"] = "true"
         else
-          attrs.delete(:"aria-hidden")
           attrs[:"aria-labelledby"] = title_id
         end
 

--- a/app/components/strata/us/icon_component.rb
+++ b/app/components/strata/us/icon_component.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module Strata
+  module US
+    # IconComponent renders a USWDS icon from the bundled sprite sheet
+    # (`@uswds/uswds/dist/img/sprite.svg`).
+    #
+    # See https://designsystem.digital.gov/components/icon/ for the catalog of
+    # available icon names and styling guidance.
+    #
+    # By default icons render as decorative (`aria-hidden="true"`). Pass
+    # `decorative: false` together with `title:` to render a meaningful icon
+    # exposed to assistive technology.
+    #
+    # @example Decorative icon
+    #   <%= render Strata::US::IconComponent.new(name: :check) %>
+    #
+    # @example Sized + extra classes
+    #   <%= render Strata::US::IconComponent.new(
+    #         name: :arrow_back, size: 4, classes: "text-primary"
+    #       ) %>
+    #
+    # @example Meaningful icon (announced by screen readers)
+    #   <%= render Strata::US::IconComponent.new(
+    #         name: :warning, decorative: false, title: "Warning",
+    #         classes: "text-warning"
+    #       ) %>
+    class IconComponent < ViewComponent::Base
+      ALLOWED_SIZES = (3..9).freeze
+
+      def initialize(name:, size: nil, decorative: true, title: nil, classes: nil, **html_attributes)
+        raise ArgumentError, "name is required" if name.nil? || name.to_s.empty?
+        validate_size!(size) unless size.nil?
+
+        @decorative = decorative
+        @title = title
+
+        if !@decorative && (@title.nil? || @title.to_s.empty?)
+          raise ArgumentError, "title is required when decorative: false"
+        end
+
+        @name = name.to_s
+        @size = size
+        @classes = classes
+        @html_attributes = html_attributes
+      end
+
+      def svg_attributes
+        attrs = @html_attributes.dup
+        attrs[:class] = svg_classes
+        attrs[:focusable] = "false"
+        attrs[:role] = "img"
+
+        if @decorative
+          attrs[:"aria-hidden"] = "true"
+        else
+          attrs[:"aria-labelledby"] = title_id
+        end
+
+        attrs
+      end
+
+      def show_title?
+        !@decorative
+      end
+
+      def title_text
+        @title
+      end
+
+      def title_id
+        @title_id ||= "icon-title-#{SecureRandom.hex(4)}"
+      end
+
+      def sprite_href
+        "#{helpers.asset_path('@uswds/uswds/dist/img/sprite.svg')}##{@name}"
+      end
+
+      private
+
+      def svg_classes
+        class_names(
+          "usa-icon",
+          { "usa-icon--size-#{@size}" => @size },
+          @classes
+        )
+      end
+
+      def validate_size!(size)
+        return if size.is_a?(Integer) && ALLOWED_SIZES.cover?(size)
+
+        raise ArgumentError,
+          "Invalid size: #{size.inspect}. Must be an Integer in #{ALLOWED_SIZES.inspect}"
+      end
+    end
+  end
+end

--- a/app/previews/strata/us/icon_component_preview.rb
+++ b/app/previews/strata/us/icon_component_preview.rb
@@ -17,8 +17,6 @@ module Strata
         search settings menu mail phone print download upload delete edit
       ].freeze
 
-      SAMPLE_COLORS = %w[default text-primary text-secondary text-success text-warning text-error].freeze
-
       # @label Playground
       # @param name select { choices: [check, close, warning, error, info, help, account_circle, arrow_back, arrow_forward, search, settings, menu, mail, phone, print, download, upload, delete, edit] }
       # @param size select { choices: [default, 3, 4, 5, 6, 7, 8, 9] }
@@ -33,7 +31,7 @@ module Strata
           name: SAMPLE_ICONS.include?(name.to_s) ? name.to_s : "check",
           size: size_arg,
           decorative: decorative,
-          title: decorative ? nil : title,
+          title: decorative ? nil : (title.presence || "Icon"),
           classes: classes
         )
       end

--- a/app/previews/strata/us/icon_component_preview.rb
+++ b/app/previews/strata/us/icon_component_preview.rb
@@ -46,8 +46,8 @@ module Strata
         render Strata::US::IconComponent.new(name: :check, size: 5)
       end
 
-      # @label Colored
-      def colored
+      # @label With color
+      def with_color
         render Strata::US::IconComponent.new(name: :check, classes: "text-success")
       end
 

--- a/app/previews/strata/us/icon_component_preview.rb
+++ b/app/previews/strata/us/icon_component_preview.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Strata
+  module US
+    # IconComponentPreview provides previews for the Strata::US::IconComponent.
+    #
+    # Use the Lookbook params tab (or URL query parameters) on the playground
+    # to switch icons, sizes, colors, and the decorative/title behavior.
+    class IconComponentPreview < Lookbook::Preview
+      layout "strata/component_preview"
+
+      # A sampling of common USWDS sprite icons for the playground dropdown.
+      # The component itself does not validate against this list — any sprite
+      # ID will work.
+      SAMPLE_ICONS = %w[
+        check close warning error info help account_circle arrow_back arrow_forward
+        search settings menu mail phone print download upload delete edit
+      ].freeze
+
+      SAMPLE_COLORS = %w[default text-primary text-secondary text-success text-warning text-error].freeze
+
+      # @label Playground
+      # @param name select { choices: [check, close, warning, error, info, help, account_circle, arrow_back, arrow_forward, search, settings, menu, mail, phone, print, download, upload, delete, edit] }
+      # @param size select { choices: [default, 3, 4, 5, 6, 7, 8, 9] }
+      # @param color select { choices: [default, text-primary, text-secondary, text-success, text-warning, text-error] }
+      # @param decorative toggle
+      # @param title text
+      def playground(name: "check", size: "default", color: "default", decorative: true, title: "Icon")
+        size_arg = (size.to_s == "default") ? nil : size.to_i
+        classes = (color.to_s == "default") ? nil : color.to_s
+
+        render Strata::US::IconComponent.new(
+          name: SAMPLE_ICONS.include?(name.to_s) ? name.to_s : "check",
+          size: size_arg,
+          decorative: decorative,
+          title: decorative ? nil : title,
+          classes: classes
+        )
+      end
+
+      # @label Default (decorative)
+      def default
+        render Strata::US::IconComponent.new(name: :check)
+      end
+
+      # @label Sized
+      def sized
+        render Strata::US::IconComponent.new(name: :check, size: 5)
+      end
+
+      # @label Colored
+      def colored
+        render Strata::US::IconComponent.new(name: :check, classes: "text-success")
+      end
+
+      # @label Meaningful (with title)
+      def meaningful
+        render Strata::US::IconComponent.new(
+          name: :warning,
+          decorative: false,
+          title: "Warning",
+          classes: "text-warning"
+        )
+      end
+    end
+  end
+end

--- a/docs/uswds-components.md
+++ b/docs/uswds-components.md
@@ -294,7 +294,7 @@ The component renders the standard USWDS `<svg class="usa-icon">…<use href="�
 - `title:` — Required when `decorative: false`; ignored when `decorative: true`.
 - `classes:` — extra CSS classes appended to the `<svg>`. USWDS color utilities (`text-primary`, `text-success`, `text-warning`, etc.) go here.
 
-Any other keyword arguments are forwarded as HTML attributes on the `<svg>`.
+Any other keyword arguments are forwarded as HTML attributes on the `<svg>`. `focusable` and `role` default to the USWDS-recommended values (`"false"` and `"img"`) but may be overridden. `aria-hidden` is component-managed — control it via `decorative:` rather than passing it directly.
 
 **Example**
 

--- a/docs/uswds-components.md
+++ b/docs/uswds-components.md
@@ -21,8 +21,9 @@ Every component accepts a `classes:` keyword for additional CSS classes and forw
 5. [Button Group](#button-group)
 6. [Card](#card)
 7. [Card Group](#card-group)
-8. [List](#list)
-9. [Table](#table)
+8. [Icon](#icon)
+9. [List](#list)
+10. [Table](#table)
 
 ---
 
@@ -275,6 +276,39 @@ At least one of header, media, body, or footer must be provided.
     <% card.with_body { "Body" } %>
   <% end %>
 <% end %>
+```
+
+---
+
+## Icon
+
+`Strata::US::IconComponent` — an SVG icon drawn from the bundled USWDS sprite sheet. See [USWDS Icon](https://designsystem.digital.gov/components/icon/) and the [Lookbook preview](../app/previews/strata/us/icon_component_preview.rb).
+
+The component renders the standard USWDS `<svg class="usa-icon">…<use href="…sprite.svg#NAME">…</svg>` markup, including the `focusable="false"` and `role="img"` attributes USWDS expects.
+
+**Options**
+
+- `name:` (required) — Symbol or String matching a USWDS sprite ID (e.g. `:check`, `:arrow_back`, `:warning`). Not validated against the sprite — a typo will simply render an empty icon, matching USWDS default behavior.
+- `size:` — Integer from `3` to `9`, mapping to `usa-icon--size-N`. Defaults to no modifier (USWDS default of `1em`).
+- `decorative:` — Defaults to `true`. When `true`, the icon is hidden from assistive technology via `aria-hidden="true"`. When `false`, a `<title>` element is rendered inside the SVG and referenced from `aria-labelledby`, so screen readers announce the icon.
+- `title:` — Required when `decorative: false`; ignored when `decorative: true`.
+- `classes:` — extra CSS classes appended to the `<svg>`. USWDS color utilities (`text-primary`, `text-success`, `text-warning`, etc.) go here.
+
+Any other keyword arguments are forwarded as HTML attributes on the `<svg>`.
+
+**Example**
+
+```erb
+<%= render Strata::US::IconComponent.new(name: :check) %>
+
+<%= render Strata::US::IconComponent.new(
+      name: :arrow_back, size: 4, classes: "text-primary"
+    ) %>
+
+<%= render Strata::US::IconComponent.new(
+      name: :warning, decorative: false, title: "Warning",
+      classes: "text-warning"
+    ) %>
 ```
 
 ---

--- a/spec/components/strata/us/icon_component_spec.rb
+++ b/spec/components/strata/us/icon_component_spec.rb
@@ -141,6 +141,29 @@ RSpec.describe Strata::US::IconComponent, type: :component do
 
       expect(page).to have_css('svg.usa-icon[aria-hidden="true"]')
     end
+
+    it "strips a nested aria: { hidden: } when decorative: false" do
+      render_icon(
+        name: :warning,
+        decorative: false,
+        title: "Warning",
+        aria: { hidden: true }
+      )
+
+      expect(page).not_to have_css("svg.usa-icon[aria-hidden]")
+    end
+
+    it "preserves other entries in the aria: hash when decorative: false" do
+      render_icon(
+        name: :warning,
+        decorative: false,
+        title: "Warning",
+        aria: { describedby: "extra-help", hidden: true }
+      )
+
+      expect(page).not_to have_css("svg.usa-icon[aria-hidden]")
+      expect(page).to have_css('svg.usa-icon[aria-describedby="extra-help"]')
+    end
   end
 
   describe "classes & html attributes" do

--- a/spec/components/strata/us/icon_component_spec.rb
+++ b/spec/components/strata/us/icon_component_spec.rb
@@ -59,6 +59,10 @@ RSpec.describe Strata::US::IconComponent, type: :component do
     it "raises ArgumentError when name is blank" do
       expect { render_icon(name: "") }.to raise_error(ArgumentError, /name/)
     end
+
+    it "raises ArgumentError when name is whitespace-only" do
+      expect { render_icon(name: "   ") }.to raise_error(ArgumentError, /name/)
+    end
   end
 
   describe "size" do
@@ -108,11 +112,28 @@ RSpec.describe Strata::US::IconComponent, type: :component do
       }.to raise_error(ArgumentError, /title/)
     end
 
+    it "raises ArgumentError when decorative: false and title is whitespace-only" do
+      expect {
+        render_icon(name: :warning, decorative: false, title: "   ")
+      }.to raise_error(ArgumentError, /title/)
+    end
+
     it "ignores title when decorative: true (the default)" do
       render_icon(name: :check, title: "Ignored")
 
       expect(page).to have_css('svg.usa-icon[aria-hidden="true"]')
       expect(page).not_to have_css("svg.usa-icon title", visible: :all)
+    end
+
+    it "strips a caller-supplied aria-hidden when decorative: false" do
+      render_icon(
+        name: :warning,
+        decorative: false,
+        title: "Warning",
+        "aria-hidden": "true"
+      )
+
+      expect(page).not_to have_css("svg.usa-icon[aria-hidden]")
     end
   end
 

--- a/spec/components/strata/us/icon_component_spec.rb
+++ b/spec/components/strata/us/icon_component_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Strata::US::IconComponent, type: :component do
+  def render_icon(**kwargs)
+    render_inline(described_class.new(**kwargs))
+  end
+
+  describe "default render" do
+    it "renders <svg class='usa-icon'> with focusable='false' and role='img'" do
+      render_icon(name: :check)
+
+      expect(page).to have_css('svg.usa-icon[focusable="false"][role="img"]')
+    end
+
+    it "renders <use> referencing the USWDS sprite asset" do
+      render_icon(name: :check)
+
+      use_node = page.find("svg.usa-icon use", visible: :all)
+      # Asset pipeline may fingerprint the filename as sprite-<digest>.svg.
+      expect(use_node[:href]).to match(%r{@uswds/uswds/dist/img/sprite[^/]*\.svg#check\z})
+    end
+
+    it "is decorative by default — sets aria-hidden and renders no <title>" do
+      render_icon(name: :check)
+
+      expect(page).to have_css('svg.usa-icon[aria-hidden="true"]')
+      expect(page).not_to have_css("svg.usa-icon title", visible: :all)
+    end
+
+    it "applies no size modifier by default" do
+      render_icon(name: :check)
+
+      svg_classes = page.find("svg.usa-icon")[:class].split
+      expect(svg_classes.grep(/usa-icon--size-/)).to be_empty
+    end
+  end
+
+  describe "name" do
+    it "accepts a Symbol" do
+      render_icon(name: :arrow_back)
+
+      use_node = page.find("svg.usa-icon use", visible: :all)
+      expect(use_node[:href]).to end_with("#arrow_back")
+    end
+
+    it "accepts a String" do
+      render_icon(name: "arrow_back")
+
+      use_node = page.find("svg.usa-icon use", visible: :all)
+      expect(use_node[:href]).to end_with("#arrow_back")
+    end
+
+    it "raises ArgumentError when name is nil" do
+      expect { render_icon(name: nil) }.to raise_error(ArgumentError, /name/)
+    end
+
+    it "raises ArgumentError when name is blank" do
+      expect { render_icon(name: "") }.to raise_error(ArgumentError, /name/)
+    end
+  end
+
+  describe "size" do
+    (3..9).each do |size|
+      it "adds usa-icon--size-#{size} when size: #{size}" do
+        render_icon(name: :check, size: size)
+        expect(page).to have_css(".usa-icon.usa-icon--size-#{size}")
+      end
+    end
+
+    it "raises ArgumentError when size is outside the allowed range" do
+      expect { render_icon(name: :check, size: 2) }.to raise_error(ArgumentError, /size/)
+      expect { render_icon(name: :check, size: 10) }.to raise_error(ArgumentError, /size/)
+    end
+
+    it "raises ArgumentError when size is not an Integer" do
+      expect { render_icon(name: :check, size: "4") }.to raise_error(ArgumentError, /size/)
+    end
+  end
+
+  describe "decorative & title" do
+    it "with decorative: false and title:, omits aria-hidden and renders a <title>" do
+      render_icon(name: :warning, decorative: false, title: "Warning")
+
+      expect(page).not_to have_css("svg.usa-icon[aria-hidden]")
+      expect(page).to have_css("svg.usa-icon title", text: "Warning", visible: :all)
+    end
+
+    it "with decorative: false, gives the <svg> an aria-labelledby pointing at the <title>" do
+      render_icon(name: :warning, decorative: false, title: "Warning")
+
+      svg = page.find("svg.usa-icon")
+      title_id = page.find("svg.usa-icon title", visible: :all)[:id]
+      expect(title_id).to be_present
+      expect(svg["aria-labelledby"]).to eq(title_id)
+    end
+
+    it "raises ArgumentError when decorative: false but no title is given" do
+      expect {
+        render_icon(name: :warning, decorative: false)
+      }.to raise_error(ArgumentError, /title/)
+    end
+
+    it "raises ArgumentError when decorative: false and title is blank" do
+      expect {
+        render_icon(name: :warning, decorative: false, title: "")
+      }.to raise_error(ArgumentError, /title/)
+    end
+
+    it "ignores title when decorative: true (the default)" do
+      render_icon(name: :check, title: "Ignored")
+
+      expect(page).to have_css('svg.usa-icon[aria-hidden="true"]')
+      expect(page).not_to have_css("svg.usa-icon title", visible: :all)
+    end
+  end
+
+  describe "classes & html attributes" do
+    it "appends classes to the <svg>" do
+      render_icon(name: :check, classes: "text-success margin-right-05")
+
+      expect(page).to have_css("svg.usa-icon.text-success.margin-right-05")
+    end
+
+    it "combines size modifier and extra classes" do
+      render_icon(name: :check, size: 5, classes: "text-primary")
+
+      expect(page).to have_css("svg.usa-icon.usa-icon--size-5.text-primary")
+    end
+
+    it "forwards id, data-*, and aria-* attributes to the <svg>" do
+      render_icon(
+        name: :check,
+        id: "my-icon",
+        data: { test: "yes" },
+        "aria-label": "checked"
+      )
+
+      expect(page).to have_css('svg.usa-icon#my-icon[data-test="yes"][aria-label="checked"]')
+    end
+  end
+end

--- a/spec/components/strata/us/icon_component_spec.rb
+++ b/spec/components/strata/us/icon_component_spec.rb
@@ -135,6 +135,12 @@ RSpec.describe Strata::US::IconComponent, type: :component do
 
       expect(page).not_to have_css("svg.usa-icon[aria-hidden]")
     end
+
+    it "ignores a caller-supplied aria-hidden when decorative: true" do
+      render_icon(name: :check, "aria-hidden": "false")
+
+      expect(page).to have_css('svg.usa-icon[aria-hidden="true"]')
+    end
   end
 
   describe "classes & html attributes" do
@@ -159,6 +165,22 @@ RSpec.describe Strata::US::IconComponent, type: :component do
       )
 
       expect(page).to have_css('svg.usa-icon#my-icon[data-test="yes"][aria-label="checked"]')
+    end
+
+    it "defaults focusable to 'false' but allows the caller to override" do
+      render_icon(name: :check)
+      expect(page).to have_css('svg.usa-icon[focusable="false"]')
+
+      render_icon(name: :check, focusable: "true")
+      expect(page).to have_css('svg.usa-icon[focusable="true"]')
+    end
+
+    it "defaults role to 'img' but allows the caller to override" do
+      render_icon(name: :check)
+      expect(page).to have_css('svg.usa-icon[role="img"]')
+
+      render_icon(name: :check, role: "presentation")
+      expect(page).to have_css('svg.usa-icon[role="presentation"]')
     end
   end
 end


### PR DESCRIPTION
Closes #365

## Summary

Adds `Strata::US::IconComponent` — a ViewComponent wrapper around the standard USWDS sprite-icon markup (`<svg class="usa-icon">…<use href="…sprite.svg#NAME">…</svg>`).

- `name:` (Symbol or String, required) — not validated against the sprite.
- `size:` (Integer 3–9) — maps to `usa-icon--size-N`. Defaults to no modifier.
- `decorative:` (default `true`) — adds `aria-hidden="true"`.
- `decorative: false` + `title:` — renders a `<title>` and wires up `aria-labelledby`.
- `classes:` — for USWDS color utilities like `text-success`, `text-warning`, etc.
- Extra HTML attributes are forwarded to the `<svg>`.

Lookbook preview included at `app/previews/strata/us/icon_component_preview.rb` with a playground + four example states. Existing ad-hoc usages are left alone — a follow-up PR can migrate them.

## Test plan

- [x] `make test` passes locally (1428 examples, 0 failures)
- [x] `make lint` clean
- [ ] Verify the Lookbook preview at /lookbook in the dummy app

🤖 Generated with [Claude Code](https://claude.ai/code)