### PR TITLE
Add USWDS ModalComponent + strata_link_to modal: keyword

### DIFF
--- a/app/components/strata/us/modal_component.html.erb
+++ b/app/components/strata/us/modal_component.html.erb
@@ -1,0 +1,26 @@
+<div <%= tag.attributes(wrapper_attributes) %>>
+  <div class="usa-modal__content">
+    <div class="usa-modal__main">
+      <% if heading? %>
+        <%= content_tag @heading_tag, heading, class: "usa-modal__heading", id: heading_id %>
+      <% end %>
+      <% if content_section? %>
+        <div class="usa-prose" id="<%= description_id %>">
+          <%= content_section %>
+        </div>
+      <% end %>
+      <% if footer? %>
+        <div class="usa-modal__footer">
+          <%= footer %>
+        </div>
+      <% end %>
+    </div>
+    <% if show_close_button? %>
+      <button type="button" class="usa-button usa-modal__close" aria-label="<%= close_aria_label %>" data-close-modal>
+        <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+          <use href="<%= asset_path("@uswds/uswds/dist/img/sprite.svg#close") %>"></use>
+        </svg>
+      </button>
+    <% end %>
+  </div>
+</div>

--- a/app/components/strata/us/modal_component.rb
+++ b/app/components/strata/us/modal_component.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module Strata
+  module US
+    # ModalComponent renders a USWDS modal — a dialog that interrupts the page
+    # to require attention or confirmation.
+    #
+    # See https://designsystem.digital.gov/components/modal/.
+    #
+    # Pair the modal with an opener element elsewhere on the page. Use
+    # +strata_link_to+ with the +modal:+ keyword for the canonical case, or
+    # splat +Strata::US::ModalComponent.opener_attrs(id)+ onto any tag helper
+    # when an anchor isn't possible (e.g. inside an existing +<form>+).
+    #
+    # All three slots — heading, content, footer — are optional. The
+    # +aria-labelledby+ / +aria-describedby+ attributes on the wrapper are
+    # only emitted when their corresponding slot is rendered.
+    #
+    # @example Basic usage
+    #   <%= render Strata::US::ModalComponent.new(id: "confirm") do |modal| %>
+    #     <% modal.with_heading { "Are you sure?" } %>
+    #     <% modal.with_content { "<p>This cannot be undone.</p>".html_safe } %>
+    #     <% modal.with_footer do %>
+    #       <%= render Strata::US::ButtonGroupComponent.new do |group| %>
+    #         <% group.with_item do %>
+    #           <%= render Strata::US::ButtonComponent.new(data: { close_modal: "" }) { "Continue" } %>
+    #         <% end %>
+    #       <% end %>
+    #     <% end %>
+    #   <% end %>
+    #
+    #   <%= strata_link_to "Open modal", modal: "confirm", as: :button %>
+    #
+    # @example Large + forced-action modal (no close button)
+    #   <%= render Strata::US::ModalComponent.new(id: "blocking", large: true, forced_action: true) do |m| %>
+    #     <% m.with_heading { "Session expiring" } %>
+    #     <% m.with_content { "<p>You'll be signed out in 30 seconds.</p>".html_safe } %>
+    #   <% end %>
+    class ModalComponent < ViewComponent::Base
+      renders_one :heading
+      renders_one :content_section
+      renders_one :footer
+
+      def initialize(
+        id:,
+        heading_tag: :h2,
+        large: false,
+        forced_action: false,
+        classes: nil,
+        **html_attributes
+      )
+        raise ArgumentError, "ModalComponent requires a non-blank id" if id.blank?
+
+        @id = id
+        @heading_tag = heading_tag
+        @large = large
+        @forced_action = forced_action
+        @classes = classes
+        @html_attributes = html_attributes
+      end
+
+      # The user-facing slot name is +with_content+ (matching the USWDS
+      # description-region concept). Internally the slot is named
+      # +content_section+ to avoid colliding with ViewComponent's implicit
+      # +content+ accessor.
+      def with_content(&block)
+        with_content_section(&block)
+      end
+
+      # Returns the HTML attribute hash that turns any element into a USWDS
+      # modal opener for the modal with the given id. Splat onto any tag
+      # helper:
+      #
+      #   <%= link_to "Open", **Strata::US::ModalComponent.opener_attrs("confirm") %>
+      #   <%= button_tag "Open", **Strata::US::ModalComponent.opener_attrs("confirm") %>
+      #
+      # +href: "#id"+ is included for graceful degradation: anchor elements
+      # jump to the modal's content when JS is off; tag helpers that don't
+      # render +href+ drop it.
+      def self.opener_attrs(id)
+        raise ArgumentError, "ModalComponent.opener_attrs requires a non-blank id" if id.blank?
+
+        {
+          href: "##{id}",
+          "aria-controls": id,
+          "data-open-modal": ""
+        }
+      end
+
+      def wrapper_attributes
+        attrs = @html_attributes.dup
+        attrs[:class] = wrapper_classes
+        attrs[:id] = @id
+        attrs[:"aria-labelledby"] = heading_id if heading?
+        attrs[:"aria-describedby"] = description_id if content_section?
+        attrs[:"data-force-action"] = "" if @forced_action
+        attrs
+      end
+
+      def wrapper_classes
+        class_names(
+          "usa-modal",
+          { "usa-modal--lg" => @large },
+          @classes
+        )
+      end
+
+      def heading_id
+        "#{@id}-heading"
+      end
+
+      def description_id
+        "#{@id}-description"
+      end
+
+      def close_aria_label
+        I18n.t("strata.components.us.modal.close_aria_label")
+      end
+
+      def show_close_button?
+        !@forced_action
+      end
+    end
+  end
+end

--- a/app/helpers/strata/links_helper.rb
+++ b/app/helpers/strata/links_helper.rb
@@ -4,7 +4,8 @@ module Strata
   # LinksHelper provides Strata's view-helper wrappers around Rails' +link_to+.
   # The helper defaults to a passthrough; pass +:as+ to opt into a styling
   # treatment (+:button+ for USWDS button styling, +:external+ for the USWDS
-  # external-link styling).
+  # external-link styling), or +:modal+ to turn the link into a USWDS modal
+  # opener.
   #
   # @example A plain link (passthrough)
   #   <%= strata_link_to "Read more", article_path %>
@@ -15,8 +16,12 @@ module Strata
   # @example A USWDS external link
   #   <%= strata_link_to "Read the docs", "https://example.gov", as: :external %>
   #
+  # @example A USWDS modal opener
+  #   <%= strata_link_to "Open", modal: "confirm", as: :button %>
+  #
   # @see Strata::US::ButtonComponent
   # @see Strata::US::LinkComponent
+  # @see Strata::US::ModalComponent
   module LinksHelper
     # Allowed values for the +:as+ keyword on +strata_link_to+.
     STRATA_LINK_TREATMENTS = %i[button external].freeze
@@ -33,13 +38,32 @@ module Strata
     # dark-background variant. Styling only — pass +target:+ / +rel:+
     # explicitly if you want the link to open in a new tab.
     #
+    # Pass +modal: "id"+ to render a USWDS modal opener for the modal with
+    # the given id. The opener attributes (+href+, +aria-controls+,
+    # +data-open-modal+) come from Strata::US::ModalComponent.opener_attrs.
+    # +modal:+ combines with +as: :button+ (the common case) or stands alone.
+    # Passing both +modal:+ and a positional URL is an error — the +href+
+    # would be ambiguous.
+    #
     # A caller-supplied +:class+ is appended to the treatment's classes.
     #
-    # Raises ArgumentError if +:as+ is unrecognized, or if +:variant+/+:size+/
-    # +:inverse+ are passed without +as: :button+.
-    def strata_link_to(*args, as: nil, **html_options, &block)
+    # Raises ArgumentError if +:as+ is unrecognized, if +:variant+/+:size+/
+    # +:inverse+ are passed without +as: :button+, or if +modal:+ is combined
+    # with a positional URL.
+    def strata_link_to(*args, as: nil, modal: nil, **html_options, &block)
       button_kwargs = html_options.extract!(:variant, :size, :inverse)
       link_kwargs = html_options.extract!(:alt)
+
+      if modal
+        if args.length >= 2
+          raise ArgumentError,
+                "strata_link_to received both `modal:` and a positional URL. " \
+                "The opener's href comes from `modal:`; pass only the link body."
+        end
+        opener = Strata::US::ModalComponent.opener_attrs(modal)
+        args << opener.delete(:href)
+        html_options.reverse_merge!(opener)
+      end
 
       case as
       when nil

--- a/app/previews/strata/us/modal_component_preview.rb
+++ b/app/previews/strata/us/modal_component_preview.rb
@@ -3,9 +3,9 @@
 module Strata
   module US
     # ModalComponentPreview shows the Strata::US::ModalComponent in its common
-    # configurations. Lookbook only renders the modal markup itself (no
-    # JavaScript-driven open/close) — the previews include a button-styled
-    # opener anchor so the relationship between trigger and dialog is visible.
+    # configurations. Each preview renders a button-styled opener via
+    # +strata_link_to ..., modal: id, as: :button+ next to the modal markup so
+    # the preview is interactive — USWDS JS is loaded in the preview layout.
     class ModalComponentPreview < Lookbook::Preview
       layout "strata/component_preview"
 
@@ -42,61 +42,13 @@ module Strata
       end
 
       # @label Basic
-      def basic
-        render Strata::US::ModalComponent.new(id: "basic-modal") do |m|
-          m.with_heading { "You have unsaved changes" }
-          m.with_content do
-            "<p>Your changes will be lost if you leave this page without saving.</p>".html_safe
-          end
-          m.with_footer do
-            render(Strata::US::ButtonGroupComponent.new) do |group|
-              group.with_item do
-                render(Strata::US::ButtonComponent.new(data: { close_modal: "" })) { "Continue" }
-              end
-              group.with_item do
-                render(Strata::US::ButtonComponent.new(variant: :unstyled, data: { close_modal: "" })) { "Go back" }
-              end
-            end
-          end
-        end
-      end
+      def basic; end
 
       # @label Large
-      def large
-        render Strata::US::ModalComponent.new(id: "large-modal", large: true) do |m|
-          m.with_heading { "Modal heading" }
-          m.with_content do
-            "<p>The large variant gives more room for longer body content or denser UI elements.</p>".html_safe
-          end
-          m.with_footer do
-            render(Strata::US::ButtonGroupComponent.new) do |group|
-              group.with_item do
-                render(Strata::US::ButtonComponent.new(data: { close_modal: "" })) { "OK" }
-              end
-            end
-          end
-        end
-      end
+      def large; end
 
       # @label Forced action (no close button)
-      def forced_action
-        render Strata::US::ModalComponent.new(id: "forced-modal", forced_action: true) do |m|
-          m.with_heading { "Session expiring" }
-          m.with_content do
-            "<p>You'll be signed out in 30 seconds. Choose an option to continue.</p>".html_safe
-          end
-          m.with_footer do
-            render(Strata::US::ButtonGroupComponent.new) do |group|
-              group.with_item do
-                render(Strata::US::ButtonComponent.new(data: { close_modal: "" })) { "Stay signed in" }
-              end
-              group.with_item do
-                render(Strata::US::ButtonComponent.new(variant: :secondary, data: { close_modal: "" })) { "Sign out" }
-              end
-            end
-          end
-        end
-      end
+      def forced_action; end
     end
   end
 end

--- a/app/previews/strata/us/modal_component_preview.rb
+++ b/app/previews/strata/us/modal_component_preview.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Strata
+  module US
+    # ModalComponentPreview shows the Strata::US::ModalComponent in its common
+    # configurations. Lookbook only renders the modal markup itself (no
+    # JavaScript-driven open/close) — the previews include a button-styled
+    # opener anchor so the relationship between trigger and dialog is visible.
+    class ModalComponentPreview < Lookbook::Preview
+      layout "strata/component_preview"
+
+      HEADING_TAGS = %w[h1 h2 h3 h4 h5 h6].freeze
+
+      # @label Playground
+      # @param id text
+      # @param heading text
+      # @param body textarea
+      # @param footer_button_label text
+      # @param large toggle
+      # @param forced_action toggle
+      # @param heading_tag select { choices: [h1, h2, h3, h4, h5, h6] }
+      def playground(
+        id: "playground-modal",
+        heading: "Are you sure?",
+        body: "Your changes will be lost if you leave this page without saving. Are you sure you want to continue?",
+        footer_button_label: "Continue without saving",
+        large: false,
+        forced_action: false,
+        heading_tag: "h2"
+      )
+        render_with_template(
+          locals: {
+            id: id,
+            heading: heading,
+            body: body,
+            footer_button_label: footer_button_label,
+            large: large,
+            forced_action: forced_action,
+            heading_tag: HEADING_TAGS.include?(heading_tag.to_s) ? heading_tag.to_sym : :h2
+          }
+        )
+      end
+
+      # @label Basic
+      def basic
+        render Strata::US::ModalComponent.new(id: "basic-modal") do |m|
+          m.with_heading { "You have unsaved changes" }
+          m.with_content do
+            "<p>Your changes will be lost if you leave this page without saving.</p>".html_safe
+          end
+          m.with_footer do
+            render(Strata::US::ButtonGroupComponent.new) do |group|
+              group.with_item do
+                render(Strata::US::ButtonComponent.new(data: { close_modal: "" })) { "Continue" }
+              end
+              group.with_item do
+                render(Strata::US::ButtonComponent.new(variant: :unstyled, data: { close_modal: "" })) { "Go back" }
+              end
+            end
+          end
+        end
+      end
+
+      # @label Large
+      def large
+        render Strata::US::ModalComponent.new(id: "large-modal", large: true) do |m|
+          m.with_heading { "Modal heading" }
+          m.with_content do
+            "<p>The large variant gives more room for longer body content or denser UI elements.</p>".html_safe
+          end
+          m.with_footer do
+            render(Strata::US::ButtonGroupComponent.new) do |group|
+              group.with_item do
+                render(Strata::US::ButtonComponent.new(data: { close_modal: "" })) { "OK" }
+              end
+            end
+          end
+        end
+      end
+
+      # @label Forced action (no close button)
+      def forced_action
+        render Strata::US::ModalComponent.new(id: "forced-modal", forced_action: true) do |m|
+          m.with_heading { "Session expiring" }
+          m.with_content do
+            "<p>You'll be signed out in 30 seconds. Choose an option to continue.</p>".html_safe
+          end
+          m.with_footer do
+            render(Strata::US::ButtonGroupComponent.new) do |group|
+              group.with_item do
+                render(Strata::US::ButtonComponent.new(data: { close_modal: "" })) { "Stay signed in" }
+              end
+              group.with_item do
+                render(Strata::US::ButtonComponent.new(variant: :secondary, data: { close_modal: "" })) { "Sign out" }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/previews/strata/us/modal_component_preview/basic.html.erb
+++ b/app/previews/strata/us/modal_component_preview/basic.html.erb
@@ -1,0 +1,18 @@
+<%= strata_link_to "Open modal", modal: "basic-modal", as: :button %>
+
+<%= render Strata::US::ModalComponent.new(id: "basic-modal") do |m| %>
+  <% m.with_heading { "You have unsaved changes" } %>
+  <% m.with_content do %>
+    <p>Your changes will be lost if you leave this page without saving.</p>
+  <% end %>
+  <% m.with_footer do %>
+    <%= render(Strata::US::ButtonGroupComponent.new) do |group| %>
+      <% group.with_item do %>
+        <%= render(Strata::US::ButtonComponent.new(data: { close_modal: "" })) { "Continue" } %>
+      <% end %>
+      <% group.with_item do %>
+        <%= render(Strata::US::ButtonComponent.new(variant: :unstyled, data: { close_modal: "" })) { "Go back" } %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/previews/strata/us/modal_component_preview/forced_action.html.erb
+++ b/app/previews/strata/us/modal_component_preview/forced_action.html.erb
@@ -1,0 +1,18 @@
+<%= strata_link_to "Open forced-action modal", modal: "forced-modal", as: :button %>
+
+<%= render Strata::US::ModalComponent.new(id: "forced-modal", forced_action: true) do |m| %>
+  <% m.with_heading { "Session expiring" } %>
+  <% m.with_content do %>
+    <p>You'll be signed out in 30 seconds. Choose an option to continue.</p>
+  <% end %>
+  <% m.with_footer do %>
+    <%= render(Strata::US::ButtonGroupComponent.new) do |group| %>
+      <% group.with_item do %>
+        <%= render(Strata::US::ButtonComponent.new(data: { close_modal: "" })) { "Stay signed in" } %>
+      <% end %>
+      <% group.with_item do %>
+        <%= render(Strata::US::ButtonComponent.new(variant: :secondary, data: { close_modal: "" })) { "Sign out" } %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/previews/strata/us/modal_component_preview/large.html.erb
+++ b/app/previews/strata/us/modal_component_preview/large.html.erb
@@ -1,0 +1,15 @@
+<%= strata_link_to "Open large modal", modal: "large-modal", as: :button %>
+
+<%= render Strata::US::ModalComponent.new(id: "large-modal", large: true) do |m| %>
+  <% m.with_heading { "Modal heading" } %>
+  <% m.with_content do %>
+    <p>The large variant gives more room for longer body content or denser UI elements.</p>
+  <% end %>
+  <% m.with_footer do %>
+    <%= render(Strata::US::ButtonGroupComponent.new) do |group| %>
+      <% group.with_item do %>
+        <%= render(Strata::US::ButtonComponent.new(data: { close_modal: "" })) { "OK" } %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/previews/strata/us/modal_component_preview/playground.html.erb
+++ b/app/previews/strata/us/modal_component_preview/playground.html.erb
@@ -1,3 +1,5 @@
+<%= strata_link_to "Open modal", modal: id, as: :button %>
+
 <%= render Strata::US::ModalComponent.new(
       id: id,
       heading_tag: heading_tag,

--- a/app/previews/strata/us/modal_component_preview/playground.html.erb
+++ b/app/previews/strata/us/modal_component_preview/playground.html.erb
@@ -1,0 +1,16 @@
+<%= render Strata::US::ModalComponent.new(
+      id: id,
+      heading_tag: heading_tag,
+      large: large,
+      forced_action: forced_action
+    ) do |m| %>
+  <% m.with_heading { heading } if heading.present? %>
+  <% m.with_content { "<p>#{body}</p>".html_safe } if body.present? %>
+  <% m.with_footer do %>
+    <%= render(Strata::US::ButtonGroupComponent.new) do |group| %>
+      <% group.with_item do %>
+        <%= render(Strata::US::ButtonComponent.new(data: { close_modal: "" })) { footer_button_label } %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/locales/strata/en.yml
+++ b/config/locales/strata/en.yml
@@ -18,6 +18,8 @@ en:
       us:
         breadcrumbs:
           aria_label: "Breadcrumb"
+        modal:
+          close_aria_label: "Close this window"
     application_forms:
       index:
         col_created_at: "Created At"

--- a/config/locales/strata/es-US.yml
+++ b/config/locales/strata/es-US.yml
@@ -15,6 +15,8 @@ es-US:
       us:
         breadcrumbs:
           aria_label: "Ruta de navegación"
+        modal:
+          close_aria_label: "Cerrar esta ventana"
     application_forms:
       index:
         col_created_at: "Fecha de creación"

--- a/docs/strata-view-helpers.md
+++ b/docs/strata-view-helpers.md
@@ -15,18 +15,19 @@ For the underlying ViewComponents, see [Strata::US::ButtonComponent](./uswds-com
 
 Defined in [Strata::LinksHelper](../app/helpers/strata/links_helper.rb).
 
-A wrapper around Rails' `link_to`. Without an `:as` keyword it's a pure passthrough — the helper exists as a single entry point for any Strata link styling. Pass `as: :button` to opt into USWDS button styling, or `as: :external` for the USWDS external-link treatment.
+A wrapper around Rails' `link_to`. Without an `:as` keyword it's a pure passthrough — the helper exists as a single entry point for any Strata link styling. Pass `as: :button` to opt into USWDS button styling, or `as: :external` for the USWDS external-link treatment. Pass `modal: "id"` to render a USWDS modal opener.
 
 **Signature**
 
 ```ruby
-strata_link_to(*args, as: nil, **html_options, &block)
+strata_link_to(*args, as: nil, modal: nil, **html_options, &block)
 ```
 
 `*args`, `**html_options`, and `&block` match Rails' `link_to`. The recognized treatments:
 
 - `as: :button` — applies USWDS button styling. Accepts the additional keywords `:variant`, `:size`, and `:inverse` (same values as [`Strata::US::ButtonComponent`](./uswds-components.md#button)).
 - `as: :external` — applies USWDS external-link styling (`usa-link usa-link--external`). Accepts `:alt` for the dark-background variant (`usa-link--alt`). The helper does not set `target` or `rel`; pass them explicitly if you want the link to open in a new tab.
+- `modal: "id"` — renders a USWDS modal opener targeting the modal with the given id. The `href`, `aria-controls`, and `data-open-modal` attributes come from [`Strata::US::ModalComponent.opener_attrs`](./uswds-components.md#modal-openers-and-opener_attrs). Combine with `as: :button` (the common case) or use standalone. Passing both `modal:` and a positional URL is an error — the `href` would be ambiguous.
 
 A caller-supplied `:class` is appended to the treatment's classes.
 
@@ -34,6 +35,7 @@ A caller-supplied `:class` is appended to the treatment's classes.
 
 - Raises `ArgumentError` if `:variant`, `:size`, or `:inverse` are passed without `as: :button` — catches the "forgot to opt in" mistake that would otherwise silently produce a plain link.
 - Raises `ArgumentError` on an unrecognized `:as` value (currently `:button` and `:external` are supported).
+- Raises `ArgumentError` if `modal:` is combined with a positional URL argument.
 
 **Examples**
 
@@ -53,6 +55,12 @@ A caller-supplied `:class` is appended to the treatment's classes.
 <%# External link that opens in a new tab — caller controls target/rel %>
 <%= strata_link_to "USWDS docs", "https://designsystem.digital.gov/",
       as: :external, target: "_blank", rel: "noopener noreferrer" %>
+
+<%# Modal opener (button-styled) %>
+<%= strata_link_to "Open", modal: "confirm", as: :button %>
+
+<%# Modal opener as a plain link %>
+<%= strata_link_to "Open", modal: "confirm" %>
 
 <%# Block form %>
 <%= strata_link_to article_path, as: :button do %>

--- a/docs/uswds-components.md
+++ b/docs/uswds-components.md
@@ -23,7 +23,8 @@ Every component accepts a `classes:` keyword for additional CSS classes and forw
 7. [Card Group](#card-group)
 8. [Link](#link)
 9. [List](#list)
-10. [Table](#table)
+10. [Modal](#modal)
+11. [Table](#table)
 
 ---
 
@@ -351,6 +352,65 @@ For other call sites where Rails owns the tag, use the class-method helper `Stra
   <% list.with_items(["Apples", "Bananas", "Cherries"]) %>
 <% end %>
 ```
+
+---
+
+## Modal
+
+`Strata::US::ModalComponent` — a USWDS modal dialog. See [USWDS Modal](https://designsystem.digital.gov/components/modal/) and the [Lookbook preview](../app/previews/strata/us/modal_component_preview.rb).
+
+The component renders only the modal markup. Pair it with an opener element elsewhere on the page — usually a [`strata_link_to`](./strata-view-helpers.md#strata_link_to) with the `modal:` keyword.
+
+**Options**
+
+- `id:` (required) — DOM id for the modal. Openers reference this id; the heading and description ids are derived from it (`#{id}-heading`, `#{id}-description`).
+- `heading_tag:` — HTML tag for the heading. Defaults to `:h2`.
+- `large:` — render the large variant (`usa-modal--lg`). Defaults to `false`.
+- `forced_action:` — add `data-force-action` to the wrapper and omit the close button. Use when the user must pick one of the footer actions (USWDS calls this the "forced action" pattern). Defaults to `false`.
+- `classes:` — extra CSS classes appended to the `.usa-modal` wrapper.
+
+Any other keyword arguments are forwarded as HTML attributes on the wrapper.
+
+**Slots**
+
+All three slots are optional. ARIA wiring (`aria-labelledby`, `aria-describedby`) is only emitted when the corresponding slot is rendered.
+
+- `with_heading { ... }` — heading text. Rendered inside `h{heading_tag}.usa-modal__heading`.
+- `with_content { ... }` — body content (HTML allowed). Wrapped in `<div class="usa-prose">`.
+- `with_footer { ... }` — footer content. Caller decides the markup (typically a `Strata::US::ButtonGroupComponent` of buttons with `data-close-modal`).
+
+**Example**
+
+```erb
+<%= render Strata::US::ModalComponent.new(id: "confirm") do |modal| %>
+  <% modal.with_heading { "Are you sure?" } %>
+  <% modal.with_content { "<p>This cannot be undone.</p>".html_safe } %>
+  <% modal.with_footer do %>
+    <%= render Strata::US::ButtonGroupComponent.new do |group| %>
+      <% group.with_item do %>
+        <%= render Strata::US::ButtonComponent.new(data: { close_modal: "" }) { "Continue" } %>
+      <% end %>
+      <% group.with_item do %>
+        <%= render Strata::US::ButtonComponent.new(variant: :unstyled, data: { close_modal: "" }) { "Cancel" } %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= strata_link_to "Open modal", modal: "confirm", as: :button %>
+```
+
+### Modal openers and `opener_attrs`
+
+For `link_to` call sites, use `strata_link_to ..., modal: "id"` (optionally combined with `as: :button`). See [strata-view-helpers.md](./strata-view-helpers.md#strata_link_to).
+
+For call sites where Rails owns the tag and `strata_link_to` doesn't fit — `button_tag` inside an existing `<form>`, a custom `tag.a`, etc. — use the class-method helper directly:
+
+```erb
+<%= button_tag "Open", **Strata::US::ModalComponent.opener_attrs("confirm") %>
+```
+
+`opener_attrs(id)` returns `{ href: "#id", "aria-controls": id, "data-open-modal": "" }`. The `href` provides JS-off graceful degradation on anchors; tag helpers that don't render `href` drop it.
 
 ---
 

--- a/spec/components/strata/us/modal_component_spec.rb
+++ b/spec/components/strata/us/modal_component_spec.rb
@@ -1,0 +1,225 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Strata::US::ModalComponent, type: :component do
+  def render_modal(**kwargs, &block)
+    render_inline(described_class.new(**kwargs), &block)
+  end
+
+  describe "wrapper" do
+    it "renders a .usa-modal with the given id" do
+      render_modal(id: "confirm") { |m| m.with_content { "body" } }
+
+      expect(page).to have_css("div.usa-modal#confirm")
+    end
+
+    it "renders the .usa-modal__content > .usa-modal__main structure" do
+      render_modal(id: "confirm") do |m|
+        m.with_heading { "Title" }
+        m.with_content { "body" }
+      end
+
+      expect(page).to have_css(".usa-modal > .usa-modal__content > .usa-modal__main")
+    end
+
+    it "raises ArgumentError when id is blank" do
+      expect { render_modal(id: "") { |m| m.with_content { "body" } } }
+        .to raise_error(ArgumentError, /id/)
+      expect { render_modal(id: nil) { |m| m.with_content { "body" } } }
+        .to raise_error(ArgumentError, /id/)
+    end
+
+    it "appends `classes:` to the wrapper" do
+      render_modal(id: "m1", classes: "margin-top-2 extra") { |m| m.with_content { "body" } }
+
+      expect(page).to have_css(".usa-modal.margin-top-2.extra")
+    end
+
+    it "forwards arbitrary html_attributes onto the wrapper" do
+      render_modal(id: "m1", data: { test: "yes" }, "aria-label": "modal-test") do |m|
+        m.with_content { "body" }
+      end
+
+      expect(page).to have_css(".usa-modal[data-test='yes'][aria-label='modal-test']")
+    end
+  end
+
+  describe "large variant" do
+    it "adds usa-modal--lg when large: true" do
+      render_modal(id: "m1", large: true) { |m| m.with_content { "body" } }
+
+      expect(page).to have_css(".usa-modal.usa-modal--lg")
+    end
+
+    it "omits usa-modal--lg by default" do
+      render_modal(id: "m1") { |m| m.with_content { "body" } }
+
+      expect(page).not_to have_css(".usa-modal--lg")
+    end
+  end
+
+  describe "forced_action" do
+    it "adds data-force-action to the wrapper when forced_action: true" do
+      render_modal(id: "m1", forced_action: true) { |m| m.with_content { "body" } }
+
+      expect(page).to have_css(".usa-modal[data-force-action]")
+    end
+
+    it "omits the close button when forced_action: true" do
+      render_modal(id: "m1", forced_action: true) { |m| m.with_content { "body" } }
+
+      expect(page).not_to have_css(".usa-modal__close")
+    end
+
+    it "renders the close button by default" do
+      render_modal(id: "m1") { |m| m.with_content { "body" } }
+
+      expect(page).to have_css("button.usa-button.usa-modal__close[type='button'][data-close-modal]")
+    end
+
+    it "does not set data-force-action by default" do
+      render_modal(id: "m1") { |m| m.with_content { "body" } }
+
+      expect(page).not_to have_css(".usa-modal[data-force-action]")
+    end
+  end
+
+  describe "close button" do
+    it "renders the USWDS sprite svg with the close glyph" do
+      render_modal(id: "m1") { |m| m.with_content { "body" } }
+
+      expect(page).to have_css(".usa-modal__close svg.usa-icon[aria-hidden='true'][focusable='false'][role='img']")
+      expect(page).to have_css(".usa-modal__close svg use")
+      use_href = page.find(".usa-modal__close svg use")[:href]
+      # Asset path may be fingerprinted in test (sprite-<digest>.svg).
+      expect(use_href).to match(%r{/assets/@uswds/uswds/dist/img/sprite.*\.svg#close})
+    end
+
+    it "uses the i18n-driven aria-label on the close button" do
+      render_modal(id: "m1") { |m| m.with_content { "body" } }
+
+      expect(page).to have_css(".usa-modal__close[aria-label='Close this window']")
+    end
+  end
+
+  describe "heading slot" do
+    it "renders the heading inside h2.usa-modal__heading with a derived id" do
+      render_modal(id: "confirm") do |m|
+        m.with_heading { "Are you sure?" }
+        m.with_content { "body" }
+      end
+
+      expect(page).to have_css("h2.usa-modal__heading#confirm-heading", text: "Are you sure?")
+    end
+
+    it "uses the heading_tag override" do
+      render_modal(id: "confirm", heading_tag: :h3) do |m|
+        m.with_heading { "Title" }
+        m.with_content { "body" }
+      end
+
+      expect(page).to have_css("h3.usa-modal__heading#confirm-heading", text: "Title")
+    end
+
+    it "wires aria-labelledby on the wrapper to the heading id when heading is present" do
+      render_modal(id: "confirm") do |m|
+        m.with_heading { "Title" }
+        m.with_content { "body" }
+      end
+
+      expect(page).to have_css(".usa-modal[aria-labelledby='confirm-heading']")
+    end
+
+    it "omits aria-labelledby and the heading element when no heading is provided" do
+      render_modal(id: "confirm") { |m| m.with_content { "body" } }
+
+      expect(page).not_to have_css(".usa-modal[aria-labelledby]")
+      expect(page).not_to have_css(".usa-modal__heading")
+    end
+
+    it "allows HTML inside the heading slot" do
+      render_modal(id: "m1") do |m|
+        m.with_heading { "<em>Saved</em>".html_safe }
+        m.with_content { "body" }
+      end
+
+      expect(page).to have_css(".usa-modal__heading em", text: "Saved")
+    end
+  end
+
+  describe "content slot" do
+    it "wraps content in .usa-prose with a derived description id" do
+      render_modal(id: "confirm") { |m| m.with_content { "This cannot be undone." } }
+
+      expect(page).to have_css("div.usa-prose#confirm-description", text: "This cannot be undone.")
+    end
+
+    it "wires aria-describedby on the wrapper to the description id when content is present" do
+      render_modal(id: "confirm") { |m| m.with_content { "body" } }
+
+      expect(page).to have_css(".usa-modal[aria-describedby='confirm-description']")
+    end
+
+    it "omits aria-describedby and the content wrapper when no content is provided" do
+      render_modal(id: "confirm") { |m| m.with_heading { "Title" } }
+
+      expect(page).not_to have_css(".usa-modal[aria-describedby]")
+      expect(page).not_to have_css(".usa-prose")
+    end
+
+    it "allows HTML inside the content slot" do
+      render_modal(id: "m1") do |m|
+        m.with_content { "<p>Congress shall make no law...</p>".html_safe }
+      end
+
+      expect(page).to have_css(".usa-prose p", text: "Congress shall make no law...")
+    end
+  end
+
+  describe "footer slot" do
+    it "wraps footer content in .usa-modal__footer" do
+      render_modal(id: "m1") do |m|
+        m.with_content { "body" }
+        m.with_footer { '<button data-close-modal>Yes</button>'.html_safe }
+      end
+
+      expect(page).to have_css(".usa-modal__footer button[data-close-modal]", text: "Yes")
+    end
+
+    it "omits the .usa-modal__footer wrapper when no footer is provided" do
+      render_modal(id: "m1") { |m| m.with_content { "body" } }
+
+      expect(page).not_to have_css(".usa-modal__footer")
+    end
+  end
+
+  describe "empty slots" do
+    it "renders a modal with no heading, content, or footer (close button still present)" do
+      render_modal(id: "m1")
+
+      expect(page).to have_css(".usa-modal#m1")
+      expect(page).not_to have_css(".usa-modal__heading")
+      expect(page).not_to have_css(".usa-prose")
+      expect(page).not_to have_css(".usa-modal__footer")
+      expect(page).to have_css(".usa-modal__close")
+      expect(page).not_to have_css(".usa-modal[aria-labelledby]")
+      expect(page).not_to have_css(".usa-modal[aria-describedby]")
+    end
+  end
+
+  describe ".opener_attrs" do
+    it "returns the trigger attribute hash for splatting onto a tag helper" do
+      expect(described_class.opener_attrs("my-modal")).to eq(
+        href: "#my-modal",
+        "aria-controls": "my-modal",
+        "data-open-modal": ""
+      )
+    end
+
+    it "raises ArgumentError on blank id" do
+      expect { described_class.opener_attrs("") }.to raise_error(ArgumentError, /id/)
+      expect { described_class.opener_attrs(nil) }.to raise_error(ArgumentError, /id/)
+    end
+  end
+end

--- a/spec/helpers/strata/links_helper_spec.rb
+++ b/spec/helpers/strata/links_helper_spec.rb
@@ -200,6 +200,72 @@ RSpec.describe Strata::LinksHelper, type: :helper do
       end
     end
 
+    context "with `modal:` keyword" do
+      it "renders an <a> with href=#id, aria-controls, and data-open-modal" do
+        result = helper.strata_link_to("Open", modal: "confirm")
+
+        expect(result).to have_element(
+          :a,
+          href: "#confirm",
+          "aria-controls": "confirm",
+          text: "Open"
+        )
+        expect(result).to have_css("a[data-open-modal]")
+      end
+
+      it "combines with `as: :button` to produce a USWDS-styled modal opener" do
+        result = helper.strata_link_to("Open", modal: "confirm", as: :button)
+
+        expect(result).to have_element(:a, href: "#confirm", class: "usa-button", text: "Open")
+        expect(result).to have_css("a[aria-controls='confirm'][data-open-modal]")
+      end
+
+      it "still applies button variant/size/inverse modifiers when combined with `as: :button`" do
+        result = helper.strata_link_to(
+          "Open",
+          modal: "confirm",
+          as: :button,
+          variant: :outline,
+          size: :big
+        )
+
+        expect(result).to have_element(:a, class: "usa-button usa-button--outline usa-button--big")
+      end
+
+      it "raises ArgumentError when a positional URL is also passed" do
+        expect { helper.strata_link_to("Open", "/somewhere", modal: "confirm") }
+          .to raise_error(ArgumentError, /modal/)
+      end
+
+      it "raises ArgumentError when the modal id is blank" do
+        expect { helper.strata_link_to("Open", modal: "") }
+          .to raise_error(ArgumentError, /id/)
+      end
+
+      it "appends a caller-supplied :class without overwriting the opener attributes" do
+        result = helper.strata_link_to(
+          "Open",
+          modal: "confirm",
+          as: :button,
+          class: "margin-top-4"
+        )
+
+        expect(result).to have_element(:a, class: "usa-button margin-top-4")
+        expect(result).to have_css("a[aria-controls='confirm'][data-open-modal]")
+      end
+
+      it "forwards arbitrary html_options to the anchor" do
+        result = helper.strata_link_to(
+          "Open",
+          modal: "confirm",
+          id: "opener",
+          data: { turbo: "false" }
+        )
+
+        expect(result).to have_element(:a, id: "opener", "data-turbo": "false")
+      end
+    end
+
     context "when :alt is passed without `as: :external`" do
       it "silently drops :alt when no :as is given (no error, no stray attribute on the <a>)" do
         result = helper.strata_link_to("Read more", "/articles/1", alt: true)


### PR DESCRIPTION
## Summary
- New `Strata::US::ModalComponent` renders the USWDS modal markup with optional heading / content / footer slots, large + forced-action variants, and ARIA wiring derived from the modal id.
- `Strata::US::ModalComponent.opener_attrs(id)` is the single source of truth for the trigger attribute hash, for splatting onto any tag helper.
- `strata_link_to` gains a `modal:` keyword that derives the opener's href and merges `aria-controls` / `data-open-modal` onto the rendered anchor.
- Lookbook preview, en + es-US close-button aria-label, and docs updates.

Closes #363

## Test plan
- [x] `make lint` clean
- [x] `make test` passes (1463 examples)
- [ ] Spot-check the Lookbook preview at /lookbook after `make start`
- [ ] Verify the modal opens in a browser with JS enabled (USWDS handles the open/close behavior)

🤖 Generated with [Claude Code](https://claude.ai/code)