### PR TITLE
Small engine cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,6 @@ spec/**/tmp/*
 # Ignore ds_store files
 **/*.DS_Store
 
-# for a library or gem, you might want to ignore these files since the code is
-# intended to run in multiple environments; otherwise, check them in:
-# Gemfile.lock
-
 # Ignore local storage files created for local testing
 spec/dummy/storage/*.sqlite[0-9]*
 spec/dummy/db/*.sqlite[0-9]*

--- a/strata.gemspec
+++ b/strata.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage    = "https://github.com/navapbc/strata-sdk-rails"
   spec.summary     = "Strata SDK for Rails"
   spec.description = "Strata SDK for building government digital services with Rails."
+  spec.license     = "Apache-2.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/navapbc/strata-sdk-rails"

--- a/strata.gemspec
+++ b/strata.gemspec
@@ -11,14 +11,12 @@ Gem::Specification.new do |spec|
   spec.summary     = "Strata SDK for Rails"
   spec.description = "Strata SDK for building government digital services with Rails."
 
-  spec.metadata["allowed_push_host"] = "https://example.com"
-
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/navapbc/strata-sdk-rails"
   spec.metadata["changelog_uri"] = "https://github.com/navapbc/strata-sdk-rails/commits/main/"
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
+    Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md", "SECURITY.md", "CODE_OF_CONDUCT.md", "CONTRIBUTING.md"]
   end
 
   spec.add_dependency "rails", ">= 7.2.2.2"


### PR DESCRIPTION
## Changes

- Removed outdated comment from `.gitignore`
- Corrected the license file to be included in the gemspec from "MIT-LICENSE" to "LICENSE"
- Added other basic files to be included in the gem (security, code of conduct, and contributing)
- Added `spec.license` as "Apache-2.0" to reduce warnings

## Context

Just doing small cleanups

## Testing

- CI passes
