### PR TITLE
Use api key instead of oauth token

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -65,7 +65,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Changes

- Replacing oauth key with anthropic api key for GH actions

## Context

- So that it doesn't charge my individual Claude account for usage and can instead refer to the Nava org

## Testing

- CI passes
