### PR TITLE
Add LeaveRequest application form to dummy app (test)

### DIFF
--- a/spec/dummy/app/controllers/leave_request_application_forms_controller.rb
+++ b/spec/dummy/app/controllers/leave_request_application_forms_controller.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+class LeaveRequestApplicationFormsController < ApplicationController
+  def index
+    @leave_request_application_forms = LeaveRequestApplicationForm.all
+  end
+
+  def new
+    @leave_request_application_form = LeaveRequestApplicationForm.new
+  end
+
+  def show
+    @leave_request_application_form = LeaveRequestApplicationForm.find(params[:id])
+  end
+
+  def edit
+    @leave_request_application_form = LeaveRequestApplicationForm.find(params[:id])
+  end
+
+  def update
+    @leave_request_application_form = LeaveRequestApplicationForm.find(params[:id])
+
+    if @leave_request_application_form.update(leave_request_application_form_params)
+      if params[:commit] == "Submit"
+        if @leave_request_application_form.submit_application
+          redirect_to @leave_request_application_form, notice: "Leave request was successfully submitted."
+          return
+        else
+          flash.now[:errors] = @leave_request_application_form.errors.full_messages
+          render :edit, status: :unprocessable_content
+          return
+        end
+      end
+
+      redirect_to @leave_request_application_form, notice: "Leave request was successfully updated."
+    else
+      flash.now[:errors] = @leave_request_application_form.errors.full_messages
+      render :edit, status: :unprocessable_content
+    end
+  end
+
+  def create
+    @leave_request_application_form = LeaveRequestApplicationForm.new(leave_request_application_form_params)
+
+    if @leave_request_application_form.save
+      if params[:commit] == "Submit"
+        if @leave_request_application_form.submit_application
+          redirect_to @leave_request_application_form, notice: "Leave request was successfully submitted."
+          return
+        else
+          flash.now[:errors] = @leave_request_application_form.errors.full_messages
+          render :new, status: :unprocessable_content
+          return
+        end
+      end
+
+      redirect_to @leave_request_application_form, notice: "Leave request was successfully saved."
+    else
+      flash.now[:errors] = @leave_request_application_form.errors.full_messages
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  private
+
+  def leave_request_application_form_params
+    params.require(:leave_request_application_form).permit(
+      :first_name,
+      :last_name,
+      :street_address,
+      :zip_code,
+      date_of_birth: [ :month, :day, :year ]
+    )
+  end
+end

--- a/spec/dummy/app/models/leave_request_application_form.rb
+++ b/spec/dummy/app/models/leave_request_application_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class LeaveRequestApplicationForm < Strata::ApplicationForm
+  include Strata::Attributes
+
+  strata_attribute :date_of_birth, :memorable_date
+
+  attribute :first_name, :string
+  attribute :last_name, :string
+  attribute :street_address, :string
+  attribute :zip_code, :string
+end

--- a/spec/dummy/app/views/leave_request_application_forms/_form.html.erb
+++ b/spec/dummy/app/views/leave_request_application_forms/_form.html.erb
@@ -1,0 +1,10 @@
+<%= strata_form_with(model: leave_request_application_form) do |f| %>
+  <%= f.text_field :first_name, label: t(".first_name") %>
+  <%= f.text_field :last_name, label: t(".last_name") %>
+  <%= f.memorable_date :date_of_birth %>
+  <%= f.text_field :street_address, label: t(".street_address") %>
+  <%= f.text_field :zip_code, label: t(".zip_code") %>
+
+  <%= f.submit "Save", value: "Save", big: true %>
+  <%= f.submit t(".submit"), value: "Submit", big: true %>
+<% end %>

--- a/spec/dummy/app/views/leave_request_application_forms/_row.html.erb
+++ b/spec/dummy/app/views/leave_request_application_forms/_row.html.erb
@@ -1,0 +1,8 @@
+<tr>
+  <td>
+    <%= link_to application_form[:created_at], application_form[:path] %>
+  </td>
+  <td>
+    <%= t("strata.application_forms.statuses.#{application_form[:status]}") %>
+  </td>
+</tr>

--- a/spec/dummy/app/views/leave_request_application_forms/edit.html.erb
+++ b/spec/dummy/app/views/leave_request_application_forms/edit.html.erb
@@ -1,0 +1,5 @@
+<% content_for :title, "Edit leave request" %>
+
+<h1>Edit leave request</h1>
+
+<%= render "form", leave_request_application_form: @leave_request_application_form %>

--- a/spec/dummy/app/views/leave_request_application_forms/index.html.erb
+++ b/spec/dummy/app/views/leave_request_application_forms/index.html.erb
@@ -1,0 +1,13 @@
+<%= render template: "strata/application_forms/index", locals: {
+  title: t(".title"),
+  intro: t(".intro"),
+  new_button_text: t(".new_button"),
+  new_path: new_leave_request_application_form_path,
+  in_progress_applications_heading: t(".in_progress_applications.heading"),
+  application_forms: @leave_request_application_forms.map { |form| {
+    created_at: form.created_at.strftime("%B %d, %Y at %I:%M %p"),
+    path: leave_request_application_form_path(form),
+    status: form.status
+  }},
+  row_view: "leave_request_application_forms/row"
+} %>

--- a/spec/dummy/app/views/leave_request_application_forms/new.html.erb
+++ b/spec/dummy/app/views/leave_request_application_forms/new.html.erb
@@ -1,0 +1,5 @@
+<% content_for :title, "New leave request" %>
+
+<h1>New leave request</h1>
+
+<%= render "form", leave_request_application_form: @leave_request_application_form %>

--- a/spec/dummy/app/views/leave_request_application_forms/show.html.erb
+++ b/spec/dummy/app/views/leave_request_application_forms/show.html.erb
@@ -1,0 +1,53 @@
+<% if @leave_request_application_form.submitted? %>
+  <%= render template: "strata/application_forms/show", locals: {
+    title: t(".title"),
+    back_link_text: t(".back"),
+    index_path: leave_request_application_forms_path,
+    created_at: @leave_request_application_form.created_at.strftime("%B %d, %Y at %I:%M %p"),
+    submitted_at: @leave_request_application_form&.submitted_at&.strftime("%B %d, %Y at %I:%M %p"),
+    current_status: @leave_request_application_form.status,
+    next_step: t(".next_step.status.#{@leave_request_application_form.status}"),
+    submitted_on_text: t(".submitted_on")
+  } %>
+<% else %>
+  <% content_for :title, t(".title") %>
+
+  <%= link_to t(".back"), leave_request_application_forms_path, class: "usa-link" %>
+
+  <h1><%= t(".title") %></h1>
+
+  <%= render partial: "strata/shared/step_indicator", locals: {
+    type: :counters,
+    steps: [:in_progress, :submitted],
+    current_step: @leave_request_application_form.status
+  } %>
+
+  <div class="margin-top-4">
+    <div class="border-top border-base-light padding-top-2 margin-top-2">
+      <div class="padding-bottom-2 border-bottom border-base-light">
+        <h3 class="font-sans-md"><%= t(".name") %></h3>
+        <p class="margin-top-1">
+          <%= [@leave_request_application_form.first_name, @leave_request_application_form.last_name].compact_blank.join(" ").presence || "-" %>
+        </p>
+      </div>
+      <div class="padding-top-2 padding-bottom-2 border-bottom border-base-light">
+        <h3 class="font-sans-md"><%= t(".date_of_birth") %></h3>
+        <p class="margin-top-1">
+          <% if @leave_request_application_form.date_of_birth.present? %>
+            <%= @leave_request_application_form.date_of_birth.strftime("%B %-d, %Y") %>
+          <% else %>
+            -
+          <% end %>
+        </p>
+      </div>
+      <div class="padding-top-2 padding-bottom-2 border-bottom border-base-light">
+        <h3 class="font-sans-md"><%= t(".address") %></h3>
+        <p class="margin-top-1">
+          <%= [@leave_request_application_form.street_address, @leave_request_application_form.zip_code].compact_blank.join(", ").presence || "-" %>
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <%= strata_link_to "Edit application", edit_leave_request_application_form_path(@leave_request_application_form), as: :button, class: "margin-top-4" %>
+<% end %>

--- a/spec/dummy/config/locales/leave_request_application_forms/en.yml
+++ b/spec/dummy/config/locales/leave_request_application_forms/en.yml
@@ -1,0 +1,25 @@
+en:
+  leave_request_application_forms:
+    index:
+      title: "Leave Requests"
+      intro: "You can submit a new leave request or continue an existing one."
+      new_button: "New Request"
+      in_progress_applications:
+        heading: "Existing requests"
+    form:
+      first_name: "First name"
+      last_name: "Last name"
+      street_address: "Street address"
+      zip_code: "ZIP code"
+      submit: "Submit"
+    show:
+      back: "Back to leave requests"
+      title: "Leave Request"
+      submitted_on: "Date submitted"
+      name: "Name"
+      date_of_birth: "Date of birth"
+      address: "Address"
+      next_step:
+        status:
+          in_progress: "Your leave request is in progress."
+          submitted: "Your request has been received. We will notify you of the decision or if further action is needed on your part."

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
 
   resources :passport_application_forms, only: [ :index, :new, :show, :create, :edit, :update ]
 
+  resources :leave_request_application_forms, only: [ :index, :new, :show, :create, :edit, :update ]
+
   resources :sample_application_forms, only: [ :index, :new, :show, :create ] do
     member do
       SampleFlow.pages.each do |page|

--- a/spec/dummy/db/migrate/20260615162948_create_leave_request_application_forms.rb
+++ b/spec/dummy/db/migrate/20260615162948_create_leave_request_application_forms.rb
@@ -1,0 +1,16 @@
+class CreateLeaveRequestApplicationForms < ActiveRecord::Migration[8.0]
+  def change
+    create_table :leave_request_application_forms do |t|
+      t.uuid :user_id
+      t.integer :status
+      t.datetime :submitted_at
+      t.string :first_name
+      t.string :last_name
+      t.date :date_of_birth
+      t.string :street_address
+      t.string :zip_code
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20260615162948_create_leave_request_application_forms.rb
+++ b/spec/dummy/db/migrate/20260615162948_create_leave_request_application_forms.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateLeaveRequestApplicationForms < ActiveRecord::Migration[8.0]
   def change
     create_table :leave_request_application_forms do |t|

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_04_221320) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_15_162948) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -19,6 +19,19 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_04_221320) do
     t.string "business_process_current_step"
     t.uuid "application_form_id"
     t.jsonb "facts", default: {}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "leave_request_application_forms", force: :cascade do |t|
+    t.uuid "user_id"
+    t.integer "status"
+    t.datetime "submitted_at"
+    t.string "first_name"
+    t.string "last_name"
+    t.date "date_of_birth"
+    t.string "street_address"
+    t.string "zip_code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
## Summary

Scaffolds a single-page `LeaveRequestApplicationForm` in the dummy app to exercise the Strata `ApplicationForm` flow end to end. **Opened as a test/demo PR** — not intended for merge.

Includes:
- **Model** — `LeaveRequestApplicationForm < Strata::ApplicationForm` with `first_name`, `last_name`, `date_of_birth` (`:memorable_date`), `street_address`, `zip_code`
- **Migration + schema** — `create_leave_request_application_forms`
- **Controller** — index / new / show / edit / create / update, with Save vs. Submit handling
- **Views** — USWDS-styled `_form`, `new`, `edit`, `show`, `index`, `_row` via `strata_form_with`
- **Routes** — `resources :leave_request_application_forms`
- **i18n** — `config/locales/leave_request_application_forms/en.yml`

## Verification

Exercised through the real HTTP stack:
- index / new render (200)
- create (Save) persists and redirects to show
- show renders name, date of birth, address
- submit flips status to `submitted`, sets `submitted_at`, shows confirmation
- editing after submit is blocked ("Cannot modify a submitted application")
- `rubocop` clean on new Ruby

## Note

The generated model originally re-declared the base attributes (`user_id`, `status`, `submitted_at`); the plain `attribute :status, :integer` shadowed the parent's `enum :status`, making `.status` return the raw integer and breaking the show view. Removed those redundant lines (they're already defined on `Strata::ApplicationForm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)