### PR TITLE
Remove created_at ordering from the closed case scope

### DIFF
--- a/app/models/strata/case.rb
+++ b/app/models/strata/case.rb
@@ -71,7 +71,6 @@ module Strata
     attribute :facts, :jsonb, default: {}
 
     default_scope { includes(:tasks) }
-    scope :closed, -> { where(status: :closed).order(created_at: :desc) }
     scope :for_application_form, ->(application_form_id) { where(application_form_id:) }
     scope :for_event, ->(event) do
       if event[:payload].key?(:case_id)


### PR DESCRIPTION
## Changes

- Delete the `scope :closed` override on `Strata::Case`. `open` and `closed` filter scopes remain, now generated solely by the existing `enum :status, open: 0, closed: 1`.

## Context

`Strata::Case` declares `enum :status, open: 0, closed: 1`, which generates filter scopes for both states. The explicit `scope :closed, -> { where(status: :closed).order(created_at: :desc) }` overwrote the enum's generated `closed` scope just to attach an ordering, while `open` kept using its generated scope untouched. The result was an unexpected asymmetry: two sibling status scopes behaving differently, one a pure filter and one a filter-plus-sort.

Ordering is a consumer-level decision, not something a generic filter scope should presume. A caller may want `created_at` order for display, or to process records in chronological order, or no ordering at all. Baking one specific sort into the filter also can't be cleanly undone: chained `.order` calls concatenate into `ORDER BY a, b`, so a consumer can't remove or reorder it without `reorder`/`unscope`. Rather than restore symmetry by adding a matching `open` override, this removes the `closed` override and leaves ordering to the consumer.

Consumer impact: any caller relying on `.closed` returning records pre-sorted by `created_at DESC` must now order explicitly. `.closed` is not called anywhere in this engine's own `app/`/`lib/` (the dummy app uses a raw `where(status: "closed")`).

## Testing

- `bundle exec rspec spec/models/strata/case_spec.rb`: 20 examples, 0 failures. No spec exercised the removed ordering.
- RuboCop clean on the changed file.
- Verified against the dummy app's concrete subclass that the scope still resolves as a filter with no ordering:
```
$ RAILS_ENV=test bin/rails runner 'puts PassportCase.closed.to_sql'
SELECT "passport_cases".* FROM "passport_cases" WHERE "passport_cases"."status" = 1
```