### PR TITLE
Add suffix to name generation

### DIFF
--- a/docs/generators.md
+++ b/docs/generators.md
@@ -95,7 +95,7 @@ bin/rails generate strata:staff
 
 The following attribute types are supported across various generators:
 
-- `name` - Creates columns for first, middle, and last name
+- `name` - Creates columns for first, middle, last name, and suffix
 - `address` - Creates columns for street lines, city, state, and zip code
 - `money` - Creates an integer column (stores cents)
 - `memorable_date` - Creates a date column

--- a/docs/strata-attributes.md
+++ b/docs/strata-attributes.md
@@ -260,7 +260,7 @@ Money attributes automatically handle type conversion and validation. Invalid mo
 
 ## Name Attribute
 
-The Name Attribute provides structured handling of person names with first, middle, and last components.
+The Name Attribute provides structured handling of person names with first, middle, last, and suffix components.
 
 ### Usage in Model
 
@@ -275,23 +275,25 @@ end
 
 ### Database Mapping
 
-A single `name` attribute creates **3 database columns** using the attribute name as a prefix:
+A single `name` attribute creates **4 database columns** using the attribute name as a prefix:
 
 For an attribute named `name`:
 - `name_first` (string)
 - `name_middle` (string)
 - `name_last` (string)
+- `name_suffix` (string)
 
 For an attribute named `owner`:
 - `owner_first` (string)
 - `owner_middle` (string)
 - `owner_last` (string)
+- `owner_suffix` (string)
 
 ### Available Methods
 
 The `Strata::Name` value object provides:
 
-- `first`, `middle`, `last` - Component accessors
+- `first`, `middle`, `last`, `suffix` - Component accessors
 - `full_name` - Returns the complete name with proper spacing
 - `to_s` - Alias for `full_name`
 - `blank?` - Returns true if all components are blank
@@ -306,20 +308,21 @@ The `Strata::Name` value object provides:
 person.name = {
   first: "John",
   middle: "A",
-  last: "Doe"
+  last: "Doe",
+  suffix: "Jr."
 }
 
 # Setting a name with a Strata::Name object
-person.name = Strata::Name.new(first: "John", middle: "A", last: "Doe")
+person.name = Strata::Name.new(first: "John", middle: "A", last: "Doe", suffix: "Jr.")
 
 # Accessing name components
 puts person.name.first # => "John"
-puts person.name.full_name # => "John A Doe"
-puts person.name.to_s # => "John A Doe"
+puts person.name.full_name # => "John A Doe Jr."
+puts person.name.to_s # => "John A Doe Jr."
 
 # Names are comparable for sorting
 names = [person1.name, person2.name, person3.name]
-sorted_names = names.sort # Sorts by last name, then first name, then middle name
+sorted_names = names.sort # Sorts by last name, then first name, then middle name, then suffix
 ```
 
 ### Validation

--- a/docs/strata-data-modeler.md
+++ b/docs/strata-data-modeler.md
@@ -44,7 +44,7 @@ bin/rails generate strata:migration AddPersonalInfoToUsers name:name date_of_bir
 
 This generates a migration with the appropriate columns:
 
-- `name_first`, `name_middle`, `name_last` (string columns for the name attribute)
+- `name_first`, `name_middle`, `name_last`, `name_suffix` (string columns for the name attribute)
 
 - `date_of_birth` (date column for the memorable_date attribute)  
 

--- a/lib/generators/strata/migration/USAGE
+++ b/lib/generators/strata/migration/USAGE
@@ -18,7 +18,7 @@ Supported Attribute Types:
     date_range           - Creates columns: start, end (both :date)
     memorable_date       - Creates columns: single :date column
     money                - Creates columns: single :integer column (stores cents)
-    name                 - Creates columns: first, middle, last (all :string)
+    name                 - Creates columns: first, middle, last, suffix (all :string)
     tax_id               - Creates columns: single :string column
     us_date              - Creates columns: single :date column
     year_month           - Creates columns: year (:integer), month (:integer)

--- a/lib/generators/strata/model/USAGE
+++ b/lib/generators/strata/model/USAGE
@@ -12,7 +12,7 @@ Examples:
     bin/rails generate strata:model User email:string profile:name birth_date:memorable_date
 
 Supported Strata Attribute Types:
-    name                 - Creates columns: name_first, name_middle, name_last (all :string)
+    name                 - Creates columns: name_first, name_middle, name_last, name_suffix (all :string)
     address              - Creates columns: address_street_line_1, address_street_line_2, address_city, address_state, address_zip_code (all :string)
     money                - Creates columns: money (:integer)
     memorable_date       - Creates columns: memorable_date (:date)


### PR DESCRIPTION
## Changes

Documents the `suffix` component that the `name` attribute / `Strata::Name` value object now generates, bringing the docs and generator USAGE files back in line with the actual behavior.

- **`docs/strata-attributes.md`** — Name Attribute now described as first, middle, last, **and suffix**; updated the column count from **3 → 4** (`name_suffix` / `owner_suffix` examples), added `suffix` to the component accessors, and updated the usage/sorting examples (`Strata::Name.new(..., suffix: "Jr.")`, `full_name # => "John A Doe Jr."`).
- **`docs/generators.md`** — `name` generator description now lists first, middle, last, and suffix columns.
- **`docs/strata-data-modeler.md`** — migration example now lists the `name_suffix` column.
- **`lib/generators/strata/migration/USAGE`** & **`lib/generators/strata/model/USAGE`** — generator help text now lists the `suffix` / `name_suffix` column.

## Context

The `name` attribute generates a fourth `*_suffix` string column and `Strata::Name` exposes a `suffix` accessor, but the documentation and generator USAGE strings still described only first/middle/last (3 columns). This left users with stale docs that under-reported the generated schema and the available accessors. This PR is docs-only — it updates the references to match the existing generated behavior.

## Testing

Docs-only change; no code paths affected. Verified the updated text matches the actual generated columns (`name_first`, `name_middle`, `name_last`, `name_suffix`) and the `Strata::Name` accessors (`first`, `middle`, `last`, `suffix`).
